### PR TITLE
export WeightInfo to allow different node template benchmarks

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -29,8 +29,8 @@ use sp_inherents::{InherentIdentifier, IsFatalError};
 use sp_runtime::{ConsensusEngineId, RuntimeString};
 
 mod exec;
+pub use crate::weights::WeightInfo;
 pub use exec::BlockExecutor;
-
 pub use pallet::*;
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
@@ -46,7 +46,6 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use crate::weights::WeightInfo;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::pallet;
 pub use pallet::*;
 
 pub mod weights;
-use weights::WeightInfo;
+pub use weights::WeightInfo;
 #[cfg(any(test, feature = "runtime-benchmarks"))]
 mod benchmarks;
 #[cfg(test)]

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -27,6 +27,7 @@
 
 use frame_support::pallet;
 
+pub use crate::weights::WeightInfo;
 pub use pallet::*;
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
@@ -44,7 +45,7 @@ mod tests;
 #[allow(deprecated)]
 #[pallet]
 pub mod pallet {
-
+	use super::*;
 	use crate::num::NonZeroU32;
 	use crate::weights::WeightInfo;
 	use frame_support::{pallet_prelude::*, traits::Randomness};

--- a/pallets/randomness/src/lib.rs
+++ b/pallets/randomness/src/lib.rs
@@ -52,6 +52,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub use crate::weights::WeightInfo;
 use frame_support::pallet;
 pub use pallet::*;
 use sp_std::vec::Vec;
@@ -77,7 +78,6 @@ pub trait GetBabeData<EpochIndex, Randomness> {
 #[pallet]
 pub mod pallet {
 	use super::*;
-	use crate::weights::WeightInfo;
 	use frame_support::traits::{Currency, ExistenceRequirement::KeepAlive};
 	use frame_support::{pallet_prelude::*, PalletId};
 	use frame_system::pallet_prelude::*;


### PR DESCRIPTION
export WeightInfo to allow different node template benchmarks. This is needed so the trait can be implemented in runtime specific files.