### PR TITLE
Add try-runtime to author-inherent

### DIFF
--- a/pallets/author-inherent/Cargo.toml
+++ b/pallets/author-inherent/Cargo.toml
@@ -48,3 +48,5 @@ runtime-benchmarks = [
 	"frame-benchmarking",
 	"nimbus-primitives/runtime-benchmarks",
 ]
+
+try-runtime = [ "frame-support/try-runtime", "nimbus-primitives/try-runtime" ]


### PR DESCRIPTION
Adds try-runtime features to pallet-author-inherent, since otherwise dancebox cannot compile with try-runtime

Not sure why it does work for moonbeam tbh