### PR TITLE
Fix try-runtime pre/post hook (#2553)

### DIFF
--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -22,6 +22,8 @@ use frame_support::{
 	traits::{OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade},
 	weights::Weight,
 };
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
 use sp_std::marker::PhantomData;
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
@@ -90,6 +92,15 @@ where
 			T::MaintenanceExecutiveHooks::on_runtime_upgrade()
 		} else {
 			T::NormalExecutiveHooks::on_runtime_upgrade()
+		}
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, TryRuntimeError> {
+		if Pallet::<T>::maintenance_mode() {
+			T::MaintenanceExecutiveHooks::try_on_runtime_upgrade(checks)
+		} else {
+			T::NormalExecutiveHooks::try_on_runtime_upgrade(checks)
 		}
 	}
 


### PR DESCRIPTION
Fix try-runtime pre/post hook execution issue. After the changes in substrate at [this PR](https://github.com/paritytech/substrate/pull/12319) the `pre_upgrade` and `post_upgrade` hooks stopped executing. This PR introduces the necessary changes to fix the issue.

It also has a [complementary PR](https://github.com/moonbeam-foundation/moonbeam/pull/2475) at the Moonbeam repo.