### PR TITLE
Fix for the breaking change from polkadot v1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,10 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.0
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,8 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "100GB"
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.0
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,15 @@ jobs:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: false
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
           # "false" if necessary for your workflow
           android: true
           dotnet: true
-          haskell: false
+          haskell: true
           large-packages: false
           docker-images: true
           swap-storage: true

--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -25,7 +25,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor as BlockNumberOf;
 use sp_std::marker::PhantomData;
 #[cfg(feature = "try-runtime")]
-use sp_std::vec::Vec;
+use sp_runtime::TryRuntimeError;
 
 pub struct ExecutiveHooks<T>(PhantomData<T>);
 
@@ -94,20 +94,11 @@ where
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+	fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, TryRuntimeError> {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaintenanceExecutiveHooks::pre_upgrade()
+			T::MaintenanceExecutiveHooks::try_on_runtime_upgrade(checks)
 		} else {
-			T::NormalExecutiveHooks::pre_upgrade()
-		}
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		if Pallet::<T>::maintenance_mode() {
-			T::MaintenanceExecutiveHooks::post_upgrade(state)
-		} else {
-			T::NormalExecutiveHooks::post_upgrade(state)
+			T::NormalExecutiveHooks::try_on_runtime_upgrade(checks)
 		}
 	}
 }

--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -23,9 +23,9 @@ use frame_support::{
 	weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor as BlockNumberOf;
-use sp_std::marker::PhantomData;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
+use sp_std::marker::PhantomData;
 
 pub struct ExecutiveHooks<T>(PhantomData<T>);
 


### PR DESCRIPTION
The pre/post_upgrade methods of a tuple of migrations should not be called directly.