### PR TITLE
implement try_on_runtime_upgrade

### DIFF
--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -110,6 +110,15 @@ where
 			T::NormalExecutiveHooks::post_upgrade(state)
 		}
 	}
+
+	#[cfg(feature = "try-runtime")]
+     fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, sp_runtime::TryRuntimeError> {
+		if Pallet::<T>::maintenance_mode() {
+			T::MaintenanceExecutiveHooks::try_on_runtime_upgrade(checks)
+		} else {
+			T::NormalExecutiveHooks::try_on_runtime_upgrade(checks)
+		}
+	 }
 }
 
 #[cfg(feature = "try-runtime")]

--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -94,24 +94,6 @@ where
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		if Pallet::<T>::maintenance_mode() {
-			T::MaintenanceExecutiveHooks::pre_upgrade()
-		} else {
-			T::NormalExecutiveHooks::pre_upgrade()
-		}
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		if Pallet::<T>::maintenance_mode() {
-			T::MaintenanceExecutiveHooks::post_upgrade(state)
-		} else {
-			T::NormalExecutiveHooks::post_upgrade(state)
-		}
-	}
-
-	#[cfg(feature = "try-runtime")]
 	fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, sp_runtime::TryRuntimeError> {
 		if Pallet::<T>::maintenance_mode() {
 			T::MaintenanceExecutiveHooks::try_on_runtime_upgrade(checks)

--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -112,13 +112,13 @@ where
 	}
 
 	#[cfg(feature = "try-runtime")]
-     fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, sp_runtime::TryRuntimeError> {
+	fn try_on_runtime_upgrade(checks: bool) -> Result<Weight, sp_runtime::TryRuntimeError> {
 		if Pallet::<T>::maintenance_mode() {
 			T::MaintenanceExecutiveHooks::try_on_runtime_upgrade(checks)
 		} else {
 			T::NormalExecutiveHooks::try_on_runtime_upgrade(checks)
 		}
-	 }
+	}
 }
 
 #[cfg(feature = "try-runtime")]


### PR DESCRIPTION
Implements `try_on_runtime_upgrade` in pallet migrations. Otherwise after the 1.3.0 upgrade we see the error:

`panicked at 'called `Result::unwrap()` on an `Err` value: Other("Usage of `pre_upgrade` with Tuples is not expected. Please use `try_on_runtime_upgrade` instead, which internally calls `pre_upgrade` -> `on_runtime_upgrade` -> `post_upgrade` for each tuple member.")`