### PR TITLE
Ensure author inherent included

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -110,10 +110,8 @@ pub mod pallet {
 				<Author<T>>::put(&author);
 			}
 
-			InherentIncluded::<T>::put(false);
-
-			// on_initialize: 2 writes
-			// on_finalize: 1 read
+			// on_initialize: 1 write
+			// on_finalize: 1 read + 1 write
 			T::DbWeight::get().reads_writes(1, 2)
 		}
 		fn on_finalize(_: BlockNumberFor<T>) {
@@ -121,7 +119,7 @@ pub mod pallet {
 			// is by checking on block finalization that the inherent set a particular storage item:
 			// https://github.com/paritytech/polkadot-sdk/issues/2841#issuecomment-1876040854
 			assert!(
-				InherentIncluded::<T>::get() == true,
+				InherentIncluded::<T>::take() == true,
 				"Block invalid, missing inherent `kick_off_authorship_validation`"
 			);
 		}

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -117,8 +117,8 @@ pub mod pallet {
 			T::DbWeight::get().reads_writes(1, 2)
 		}
 		fn on_finalize(_: BlockNumberFor<T>) {
-			// According to parity, the only wayt to ensure that a mandatory inherent is included
-			// is by checking on block finaliztion that the inherent set a particular storage item:
+			// According to parity, the only way to ensure that a mandatory inherent is included
+			// is by checking on block finalization that the inherent set a particular storage item:
 			// https://github.com/paritytech/polkadot-sdk/issues/2841#issuecomment-1876040854
 			assert!(
 				InherentIncluded::<T>::get() == true,

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -117,6 +117,9 @@ pub mod pallet {
 			T::DbWeight::get().reads_writes(1, 2)
 		}
 		fn on_finalize(_: BlockNumberFor<T>) {
+			// According to parity, the only wayt to ensure that a mandatory inherent is included
+			// is by checking on block finaliztion that the inherent set a particular storage item:
+			// https://github.com/paritytech/polkadot-sdk/issues/2841#issuecomment-1876040854
 			assert!(
 				InherentIncluded::<T>::get() == true,
 				"Block invalid, missing inherent `kick_off_authorship_validation`"

--- a/pallets/author-inherent/src/weights.rs
+++ b/pallets/author-inherent/src/weights.rs
@@ -77,7 +77,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 25_775_000 picoseconds.
 		Weight::from_parts(26_398_000, 10418)
 			.saturating_add(T::DbWeight::get().reads(6_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 }
 


### PR DESCRIPTION
According to parity, the only way to ensure that a mandatory inherent is included is by checking on block finalization that the inherent set a particular storage item: https://github.com/paritytech/polkadot-sdk/issues/2841#issuecomment-1876040854

