### PR TITLE
Migrate maintenance mode hooks and handlers to moonkit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5483,6 +5483,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maintenance-mode-primitives"
+version = "0.1.0"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "pallet-migrations",
+ "sp-runtime",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/primitives/maintenance-mode-primitives/Cargo.toml
+++ b/primitives/maintenance-mode-primitives/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "maintenance-mode-primitives"
+authors = { workspace = true }
+description = "Primitives for Maintenance Mode pallet"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+cumulus-primitives-core = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-migrations = { workspace = true }
+sp-runtime = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+    "cumulus-primitives-core/std",
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-migrations/std",
+	"sp-runtime/std",
+]
+runtime-benchmarks = []
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "sp-runtime/try-runtime"
+]

--- a/primitives/maintenance-mode-primitives/src/handlers.rs
+++ b/primitives/maintenance-mode-primitives/src/handlers.rs
@@ -1,0 +1,54 @@
+// Copyright Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::marker::PhantomData;
+use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
+use frame_support::{
+	traits::Get,
+	weights::Weight,
+};
+
+pub struct NormalDmpHandler<Runtime, Handler>(PhantomData<(Runtime, Handler)>);
+impl<Runtime, Handler> DmpMessageHandler for NormalDmpHandler<Runtime, Handler>
+where
+	Runtime: frame_system::Config + pallet_migrations::Config,
+	Handler: DmpMessageHandler,
+{
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		limit: Weight,
+	) -> Weight {
+		(if pallet_migrations::Pallet::<Runtime>::should_pause_xcm() {
+			Handler::handle_dmp_messages(iter, Weight::zero())
+		} else {
+			Handler::handle_dmp_messages(iter, limit)
+		}) + <Runtime as frame_system::Config>::DbWeight::get().reads(1)
+	}
+}
+
+pub struct MaintenanceDmpHandler<Handler>(PhantomData<Handler>);
+impl<Handler: DmpMessageHandler> DmpMessageHandler for MaintenanceDmpHandler<Handler> {
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		_limit: Weight,
+	) -> Weight {
+		Handler::handle_dmp_messages(iter, Weight::zero())
+	}
+}

--- a/primitives/maintenance-mode-primitives/src/hooks.rs
+++ b/primitives/maintenance-mode-primitives/src/hooks.rs
@@ -1,0 +1,68 @@
+// Copyright Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::marker::PhantomData;
+use frame_support::{
+	traits::{OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade},
+	weights::Weight,
+};
+
+#[cfg(feature = "try-runtime")]
+use sp_runtime::DispatchError;
+
+pub type BlockNumber = u32;
+
+/// The hooks we want to run in Maintenance Mode
+pub struct MaintenanceHooks<T>(PhantomData<T>);
+impl<T: OnInitialize<BlockNumber>> OnInitialize<BlockNumber> for MaintenanceHooks<T> {
+	fn on_initialize(n: BlockNumber) -> Weight {
+		T::on_initialize(n)
+	}
+}
+
+// We override onIdle for xcmQueue and dmpQueue pallets to not process messages inside it
+impl<T> OnIdle<BlockNumber> for MaintenanceHooks<T> {
+	fn on_idle(_n: BlockNumber, _max_weight: Weight) -> Weight {
+		Weight::zero()
+	}
+}
+
+impl<T: OnRuntimeUpgrade> OnRuntimeUpgrade for MaintenanceHooks<T> {
+	fn on_runtime_upgrade() -> Weight {
+		T::on_runtime_upgrade()
+	}
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+		T::pre_upgrade()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		T::post_upgrade(state)
+	}
+}
+
+impl<T: OnFinalize<BlockNumber>> OnFinalize<BlockNumber> for MaintenanceHooks<T> {
+	fn on_finalize(n: BlockNumber) {
+		T::on_finalize(n)
+	}
+}
+
+impl<T: OffchainWorker<BlockNumber>> OffchainWorker<BlockNumber> for MaintenanceHooks<T> {
+	fn offchain_worker(n: BlockNumber) {
+		T::offchain_worker(n)
+	}
+}

--- a/primitives/maintenance-mode-primitives/src/lib.rs
+++ b/primitives/maintenance-mode-primitives/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod handlers;
+pub mod hooks;


### PR DESCRIPTION
This PR adds a new primitives package called `maintenance-mode-primitives`, which contains all the maintenance mode hooks and DMP handlers that are common (at least to Tanssi and Moonbeam). This way respective runtime files can be cleaned up and make use of this primitive, that is basically shared code between them.