### PR TITLE
add expected blocktime to pallet_async_backing

### DIFF
--- a/pallets/async-backing/src/lib.rs
+++ b/pallets/async-backing/src/lib.rs
@@ -94,6 +94,9 @@ pub mod pallet {
 
 		/// A way to get the current parachain slot and verify it's validity against the relay slot.
 		type GetAndVerifySlot: GetAndVerifySlot;
+
+		#[pallet::constant]
+		type ExpectedBlockTime: Get<Self::Moment>;
 	}
 
 	/// First tuple element is the highest slot that has been seen in the history of this chain.

--- a/pallets/async-backing/src/lib.rs
+++ b/pallets/async-backing/src/lib.rs
@@ -95,6 +95,8 @@ pub mod pallet {
 		/// A way to get the current parachain slot and verify it's validity against the relay slot.
 		type GetAndVerifySlot: GetAndVerifySlot;
 
+		/// Purely informative, but used by mocking tools like chospticks to allow knowing how to mock
+		/// blocks
 		#[pallet::constant]
 		type ExpectedBlockTime: Get<Self::Moment>;
 	}

--- a/pallets/async-backing/src/mock.rs
+++ b/pallets/async-backing/src/mock.rs
@@ -81,6 +81,7 @@ impl pallet_timestamp::Config for Test {
 parameter_types! {
 	pub const AllowMultipleBlocksPerSlot: bool = true;
 	pub const SlotDuration: u64 = 12000;
+	type ExpectedBlockTime = ConstU64<1>;
 }
 
 impl async_backing::Config for Test {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -638,9 +638,14 @@ impl pallet_author_slot_filter::Config for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const ExpectedBlockTime: u64 = MILLISECS_PER_BLOCK;
+}
+
 impl pallet_async_backing::Config for Runtime {
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	type GetAndVerifySlot = pallet_async_backing::RelaySlot;
+	type ExpectedBlockTime = ExpectedBlockTime;
 }
 
 parameter_types! {


### PR DESCRIPTION
Adds expected blocktime to `pallet_async_backing`. This is purely informative but it helps cases where this needs to be known (e.g., mocking tools like chopsticks).

Similar to Babe: https://github.com/paritytech/polkadot-sdk/blob/3c6ebd9e9bfda58f199cba6ec3023e0d12d6b506/substrate/frame/babe/src/lib.rs#L135