### PR TITLE
Add `OnAssetCreated` and `OnAssetDestroyed` hook

### DIFF
--- a/pallets/foreign-asset-creator/src/lib.rs
+++ b/pallets/foreign-asset-creator/src/lib.rs
@@ -36,9 +36,24 @@ pub trait ForeignAssetCreatedHook<ForeignAsset, AssetId, AssetBalance> {
 	);
 }
 
+impl<ForeignAsset, AssetId, AssetBalance>
+	ForeignAssetCreatedHook<ForeignAsset, AssetId, AssetBalance> for ()
+{
+	fn on_asset_created(
+		_foreign_asset: &ForeignAsset,
+		_asset_id: &AssetId,
+		_min_balance: &AssetBalance,
+	) {
+	}
+}
+
 /// Trait for the OnForeignAssetDeregistered hook
 pub trait ForeignAssetDestroyedHook<ForeignAsset, AssetId> {
 	fn on_asset_destroyed(foreign_asset: &ForeignAsset, asset_id: &AssetId);
+}
+
+impl<ForeignAsset, AssetId> ForeignAssetDestroyedHook<ForeignAsset, AssetId> for () {
+	fn on_asset_destroyed(_foreign_asset: &ForeignAsset, _asset_id: &AssetId) {}
 }
 
 #[pallet]

--- a/pallets/foreign-asset-creator/src/lib.rs
+++ b/pallets/foreign-asset-creator/src/lib.rs
@@ -27,6 +27,20 @@ pub mod mock;
 #[cfg(test)]
 pub mod tests;
 
+/// Trait for the OnForeignAssetRegistered hook
+pub trait ForeignAssetCreatedHook<ForeignAsset, AssetId, AssetBalance> {
+	fn on_asset_created(
+		foreign_asset: &ForeignAsset,
+		asset_id: &AssetId,
+		min_balance: &AssetBalance,
+	);
+}
+
+/// Trait for the OnForeignAssetDeregistered hook
+pub trait ForeignAssetDestroyedHook<ForeignAsset, AssetId> {
+	fn on_asset_destroyed(foreign_asset: &ForeignAsset, asset_id: &AssetId);
+}
+
 #[pallet]
 pub mod pallet {
 	use super::*;
@@ -66,6 +80,16 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Hook to be called when new foreign asset is registered.
+		type OnForeignAssetCreated: ForeignAssetCreatedHook<
+			Self::ForeignAsset,
+			AssetId<Self>,
+			AssetBalance<Self>,
+		>;
+
+		/// Hook to be called when foreign asset is de-registered.
+		type OnForeignAssetDestroyed: ForeignAssetDestroyedHook<Self::ForeignAsset, AssetId<Self>>;
 	}
 
 	pub type AssetBalance<T> = <<T as Config>::Fungibles as fungibles::Inspect<
@@ -152,6 +176,8 @@ pub mod pallet {
 			AssetIdToForeignAsset::<T>::insert(&asset_id, &foreign_asset);
 			ForeignAssetToAssetId::<T>::insert(&foreign_asset, &asset_id);
 
+			T::OnForeignAssetCreated::on_asset_created(&foreign_asset, &asset_id, &min_balance);
+
 			Self::deposit_event(Event::ForeignAssetCreated {
 				asset_id,
 				foreign_asset,
@@ -232,6 +258,8 @@ pub mod pallet {
 			AssetIdToForeignAsset::<T>::remove(&asset_id);
 			// Remove from ForeignAssetToAssetId
 			ForeignAssetToAssetId::<T>::remove(&foreign_asset);
+
+			T::OnForeignAssetDestroyed::on_asset_destroyed(&foreign_asset, &asset_id);
 
 			Self::deposit_event(Event::ForeignAssetDestroyed {
 				asset_id,

--- a/pallets/foreign-asset-creator/src/mock.rs
+++ b/pallets/foreign-asset-creator/src/mock.rs
@@ -207,8 +207,8 @@ impl Config for Test {
 	type ForeignAssetDestroyerOrigin = EnsureRoot<AccountId>;
 	type Fungibles = Assets;
 	type WeightInfo = ();
-	type OnForeignAssetCreated = NoteDownHook<MultiLocation, AssetId, Balance>;
-	type OnForeignAssetDestroyed = NoteDownHook<MultiLocation, AssetId, Balance>;
+	type OnForeignAssetCreated = NoteDownHook<Location, AssetId, Balance>;
+	type OnForeignAssetDestroyed = NoteDownHook<Location, AssetId, Balance>;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/foreign-asset-creator/src/mock.rs
+++ b/pallets/foreign-asset-creator/src/mock.rs
@@ -16,12 +16,14 @@
 
 use super::*;
 use crate as pallet_foreign_asset_creator;
+use std::marker::PhantomData;
 
 use frame_support::{
-	construct_runtime, parameter_types,
+	construct_runtime, parameter_types, storage,
 	traits::{ConstU32, Everything},
 };
 use frame_system::EnsureRoot;
+use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_runtime::BuildStorage;
@@ -126,6 +128,77 @@ impl pallet_assets::Config for Test {
 	}
 }
 
+/// Gets parameters of last `ForeignAssetCreatedHook::on_asset_created` hook invocation
+pub fn get_asset_created_hook_invocation<
+	ForeignAsset: Decode,
+	AssetId: Decode,
+	AssetBalance: Decode,
+>() -> Option<(ForeignAsset, AssetId, AssetBalance)> {
+	storage::unhashed::get_raw(b"____on_foreign_asset_created")
+		.map(|output| Decode::decode(&mut output.as_slice()).expect("Decoding should work"))
+}
+
+/// Notes down parameters of current `ForeignAssetCreatedHook::on_asset_created` hook invocation
+fn note_on_asset_created_hook_invocation<
+	ForeignAsset: Encode,
+	AssetId: Encode,
+	AssetBalance: Encode,
+>(
+	foreign_asset: &ForeignAsset,
+	asset_id: &AssetId,
+	min_balance: &AssetBalance,
+) {
+	storage::unhashed::put_raw(
+		b"____on_foreign_asset_created",
+		(foreign_asset, asset_id, min_balance).encode().as_slice(),
+	);
+}
+
+/// Gets parameters of last `ForeignAssetDestroyedHook::on_asset_destroyed` hook invocation
+pub fn get_asset_destroyed_hook_invocation<ForeignAsset: Decode, AssetId: Decode>(
+) -> Option<(ForeignAsset, AssetId)> {
+	storage::unhashed::get_raw(b"____on_foreign_asset_destroyed")
+		.map(|output| Decode::decode(&mut output.as_slice()).expect("Decoding should work"))
+}
+
+/// Notes down parameters of current `ForeignAssetDestroyedHook::on_asset_destroyed` hook invocation
+fn note_on_asset_destroyed_hook_invocation<ForeignAsset: Encode, AssetId: Encode>(
+	foreign_asset: &ForeignAsset,
+	asset_id: &AssetId,
+) {
+	storage::unhashed::put_raw(
+		b"____on_foreign_asset_destroyed",
+		(foreign_asset, asset_id).encode().as_slice(),
+	);
+}
+
+/// Test hook that records the hook invocation with exact params
+pub struct NoteDownHook<ForeignAsset, AssetId, AssetBalance>(
+	PhantomData<(ForeignAsset, AssetId, AssetBalance)>,
+);
+
+impl<ForeignAsset: Encode, AssetId: Encode, AssetBalance: Encode>
+	ForeignAssetCreatedHook<ForeignAsset, AssetId, AssetBalance>
+	for NoteDownHook<ForeignAsset, AssetId, AssetBalance>
+{
+	fn on_asset_created(
+		foreign_asset: &ForeignAsset,
+		asset_id: &AssetId,
+		min_balance: &AssetBalance,
+	) {
+		note_on_asset_created_hook_invocation(foreign_asset, asset_id, min_balance);
+	}
+}
+
+impl<ForeignAsset: Encode, AssetId: Encode, AssetBalance>
+	ForeignAssetDestroyedHook<ForeignAsset, AssetId>
+	for NoteDownHook<ForeignAsset, AssetId, AssetBalance>
+{
+	fn on_asset_destroyed(foreign_asset: &ForeignAsset, asset_id: &AssetId) {
+		note_on_asset_destroyed_hook_invocation(foreign_asset, asset_id);
+	}
+}
+
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type ForeignAsset = Location;
@@ -134,6 +207,8 @@ impl Config for Test {
 	type ForeignAssetDestroyerOrigin = EnsureRoot<AccountId>;
 	type Fungibles = Assets;
 	type WeightInfo = ();
+	type OnForeignAssetCreated = NoteDownHook<MultiLocation, AssetId, Balance>;
+	type OnForeignAssetDestroyed = NoteDownHook<MultiLocation, AssetId, Balance>;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/foreign-asset-creator/src/tests.rs
+++ b/pallets/foreign-asset-creator/src/tests.rs
@@ -41,8 +41,15 @@ fn creating_foreign_works() {
 		);
 		expect_events(vec![crate::Event::ForeignAssetCreated {
 			asset_id: 1,
-			foreign_asset: Location::parent(),
-		}])
+			foreign_asset: MultiLocation::parent(),
+		}]);
+
+		let (foreign_asset, asset_id, min_balance): (MultiLocation, u32, u64) =
+			get_asset_created_hook_invocation()
+				.expect("Decoding of invocation data should not fail");
+		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(asset_id, 1u32);
+		assert_eq!(min_balance, 1u64);
 	});
 }
 
@@ -205,6 +212,13 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 			1u64,
 		));
 
+		let (foreign_asset, asset_id, min_balance): (MultiLocation, u32, u64) =
+			get_asset_created_hook_invocation()
+				.expect("Decoding of invocation data should not fail");
+		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(asset_id, 1u32);
+		assert_eq!(min_balance, 1u64);
+
 		assert_ok!(ForeignAssetCreator::destroy_foreign_asset(
 			RuntimeOrigin::root(),
 			1
@@ -223,6 +237,11 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 				asset_id: 1,
 				foreign_asset: Location::parent(),
 			},
-		])
+		]);
+
+		let (foreign_asset, asset_id): (MultiLocation, u32) = get_asset_destroyed_hook_invocation()
+			.expect("Decoding of invocation data should not fail");
+		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(asset_id, 1u32);
 	});
 }

--- a/pallets/foreign-asset-creator/src/tests.rs
+++ b/pallets/foreign-asset-creator/src/tests.rs
@@ -41,13 +41,13 @@ fn creating_foreign_works() {
 		);
 		expect_events(vec![crate::Event::ForeignAssetCreated {
 			asset_id: 1,
-			foreign_asset: MultiLocation::parent(),
+			foreign_asset: Location::parent(),
 		}]);
 
-		let (foreign_asset, asset_id, min_balance): (MultiLocation, u32, u64) =
+		let (foreign_asset, asset_id, min_balance): (Location, u32, u64) =
 			get_asset_created_hook_invocation()
 				.expect("Decoding of invocation data should not fail");
-		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(foreign_asset, Location::parent());
 		assert_eq!(asset_id, 1u32);
 		assert_eq!(min_balance, 1u64);
 	});
@@ -212,10 +212,10 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 			1u64,
 		));
 
-		let (foreign_asset, asset_id, min_balance): (MultiLocation, u32, u64) =
+		let (foreign_asset, asset_id, min_balance): (Location, u32, u64) =
 			get_asset_created_hook_invocation()
 				.expect("Decoding of invocation data should not fail");
-		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(foreign_asset, Location::parent());
 		assert_eq!(asset_id, 1u32);
 		assert_eq!(min_balance, 1u64);
 
@@ -239,9 +239,9 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 			},
 		]);
 
-		let (foreign_asset, asset_id): (MultiLocation, u32) = get_asset_destroyed_hook_invocation()
+		let (foreign_asset, asset_id): (Location, u32) = get_asset_destroyed_hook_invocation()
 			.expect("Decoding of invocation data should not fail");
-		assert_eq!(foreign_asset, MultiLocation::parent());
+		assert_eq!(foreign_asset, Location::parent());
 		assert_eq!(asset_id, 1u32);
 	});
 }


### PR DESCRIPTION
## Description
This PR adds `OnForeignAssetCreated` and `OnForeignAssetDestroyed` hook in foreign asset creator pallet which allows adding hooks during runtime construction to be called when a foreign asset is created or destroyed.

I have modified tests to add checks to make sure hook is invoked with right parameters.