### PR TITLE
pallet-emergency-para-xcm: pause xcm message processing when chain is stalled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6870,6 +6870,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-emergency-para-xcm"
+version = "0.1.0"
+dependencies = [
+ "cumulus-pallet-parachain-system",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-message-queue",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 8.0.0",
+ "xcm-primitives",
+]
+
+[[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
 source = "git+https://github.com/paritytech/frontier?branch=polkadot-v1.7.0#c5d6daa9ffd46c0a85915526aa26d200fd635e30"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,7 +6875,6 @@ version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,6 +6875,7 @@ version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "approx"
@@ -214,7 +214,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -932,7 +932,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1435,7 +1435,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2071,7 +2071,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2378,7 +2378,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2418,7 +2418,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2435,7 +2435,7 @@ checksum = "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2670,7 +2670,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.53",
  "termcolor",
  "toml 0.8.10",
  "walkdir",
@@ -2849,7 +2849,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2860,7 +2860,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3095,7 +3095,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3428,7 +3428,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3557,7 +3557,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3569,7 +3569,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3579,7 +3579,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3806,7 +3806,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5342,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
@@ -5408,7 +5408,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5422,7 +5422,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5433,7 +5433,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5444,7 +5444,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6278,7 +6278,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6885,7 +6885,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+ "substrate-test-runtime-client",
  "xcm-primitives",
 ]
 
@@ -7037,7 +7038,7 @@ dependencies = [
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "libsecp256k1",
  "pallet-assets",
  "pallet-balances",
@@ -7051,7 +7052,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
 ]
 
 [[package]]
@@ -7658,7 +7659,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8145,7 +8146,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8186,7 +8187,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9309,39 +9310,39 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
 
 [[package]]
 name = "polkavm-derive"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9516,7 +9517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9609,7 +9610,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9655,7 +9656,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9723,7 +9724,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9980,7 +9981,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -10612,7 +10613,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -11621,7 +11622,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -11909,9 +11910,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -11927,13 +11928,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -12376,7 +12377,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -12624,7 +12625,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -12639,7 +12640,6 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
  "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
 
 [[package]]
@@ -12662,7 +12662,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -12681,17 +12681,17 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -12708,11 +12708,10 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
 
@@ -12927,7 +12926,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12953,20 +12952,20 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "Inflector",
  "expander 2.0.0",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -13052,7 +13051,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 
 [[package]]
 name = "sp-storage"
@@ -13070,14 +13069,13 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
 
 [[package]]
@@ -13108,10 +13106,9 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "parity-scale-codec",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -13190,7 +13187,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -13209,13 +13206,12 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7e7c488ba8d3709ac79050a08a80ec4a9cafd091"
+source = "git+https://github.com/paritytech/polkadot-sdk#46ba85500ffc77fa8e267c5f38b2c213550d68fa"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "wasmtime",
 ]
 
@@ -13457,7 +13453,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -13540,6 +13536,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-test-client"
+version = "2.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0#162c6796bac740802fe11c9e39f3094677d1f08f"
+dependencies = [
+ "array-bytes 6.2.2",
+ "async-trait",
+ "futures 0.3.30",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-offchain",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "tokio",
+]
+
+[[package]]
+name = "substrate-test-runtime"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0#162c6796bac740802fe11c9e39f3094677d1f08f"
+dependencies = [
+ "array-bytes 6.2.2",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "log",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sc-service",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-state-machine",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "trie-db",
+]
+
+[[package]]
+name = "substrate-test-runtime-client"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0#162c6796bac740802fe11c9e39f3094677d1f08f"
+dependencies = [
+ "futures 0.3.30",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "substrate-test-client",
+ "substrate-test-runtime",
+]
+
+[[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0#162c6796bac740802fe11c9e39f3094677d1f08f"
@@ -13588,9 +13671,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13705,7 +13788,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -13716,7 +13799,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -13860,7 +13943,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -14052,7 +14135,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -14095,7 +14178,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -14514,7 +14597,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -14548,7 +14631,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -15397,7 +15480,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -15446,7 +15529,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -15466,7 +15549,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.53",
 ]
 
 [[package]]

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -29,6 +29,9 @@ cumulus-pallet-parachain-system = { workspace = true }
 # Polkadot
 polkadot-parachain-primitives = { workspace = true }
 
+# Benchmarks
+frame-benchmarking = { workspace = true, optional = true }
+
 [dev-dependencies]
 sp-core = { workspace = true, features = [ "std" ] }
 sp-io = { workspace = true, features = [ "std" ] }
@@ -37,6 +40,7 @@ substrate-test-runtime-client = { workspace = true }
 [features]
 default = [ "std" ]
 std = [
+	"frame-benchmarking/std",
 	"cumulus-primitives-core/std",
 	"cumulus-pallet-parachain-system/std",
 	"frame-support/std",
@@ -48,4 +52,9 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+runtime-benchmarks = [
+	"frame-benchmarking",
+]
+
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -49,4 +49,8 @@ std = [
 	"sp-std/std",
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [ 
+	"frame-support/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"pallet-message-queue/try-runtime",
+]

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -37,9 +37,12 @@ sp-io = { workspace = true, features = [ "std" ] }
 default = [ "std" ]
 std = [
 	"cumulus-primitives-core/std",
+	"cumulus-pallet-parachain-system/std",
 	"frame-support/std",
 	"frame-system/std",
+	"log/std",
 	"pallet-message-queue/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -29,9 +29,6 @@ cumulus-pallet-parachain-system = { workspace = true }
 # Polkadot
 polkadot-parachain-primitives = { workspace = true }
 
-# Benchmarks
-frame-benchmarking = { workspace = true, optional = true }
-
 [dev-dependencies]
 sp-core = { workspace = true, features = [ "std" ] }
 sp-io = { workspace = true, features = [ "std" ] }
@@ -40,7 +37,6 @@ substrate-test-runtime-client = { workspace = true }
 [features]
 default = [ "std" ]
 std = [
-	"frame-benchmarking/std",
 	"cumulus-primitives-core/std",
 	"cumulus-pallet-parachain-system/std",
 	"frame-support/std",
@@ -51,10 +47,6 @@ std = [
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",
-]
-
-runtime-benchmarks = [
-	"frame-benchmarking",
 ]
 
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -24,7 +24,7 @@ sp-std = { workspace = true }
 
 # Cumulus
 cumulus-primitives-core = { workspace = true }
-cumulus-pallet-parachain-system = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true, features = ["parameterized-consensus-hook"] }
 
 # Polkadot
 polkadot-parachain-primitives = { workspace = true }

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -44,6 +44,7 @@ std = [
 	"log/std",
 	"pallet-message-queue/std",
 	"parity-scale-codec/std",
+	"polkadot-parachain-primitives/std",
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "pallet-emergency-para-xcm"
+authors = { workspace = true }
+description = "Emergency mode for parachain incoming XCM"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+
+# Local
+xcm-primitives = { workspace = true }
+
+# Crates.io
+log = { workspace = true }
+
+# Substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-message-queue = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true, features = [ "derive" ] }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+# Cumulus
+cumulus-primitives-core = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
+
+# Polkadot
+polkadot-parachain-primitives = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true, features = [ "std" ] }
+sp-io = { workspace = true, features = [ "std" ] }
+
+[features]
+default = [ "std" ]
+std = [
+	"cumulus-primitives-core/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-message-queue/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/emergency-para-xcm/Cargo.toml
+++ b/pallets/emergency-para-xcm/Cargo.toml
@@ -32,6 +32,7 @@ polkadot-parachain-primitives = { workspace = true }
 [dev-dependencies]
 sp-core = { workspace = true, features = [ "std" ] }
 sp-io = { workspace = true, features = [ "std" ] }
+substrate-test-runtime-client = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -115,7 +115,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight((0, DispatchClass::Operational))]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 2), DispatchClass::Operational))]
 		pub fn paused_to_normal(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			T::PausedToNormalOrigin::ensure_origin(origin)?;
 
@@ -131,7 +131,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(1)]
-		#[pallet::weight((1_000_000, DispatchClass::Operational))]
+		#[pallet::weight((T::DbWeight::get().read, DispatchClass::Operational))]
 		pub fn fast_authorize_upgrade(origin: OriginFor<T>, code_hash: T::Hash) -> DispatchResult {
 			T::FastAuthorizeUpgradeOrigin::ensure_origin(origin)?;
 			ensure!(

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -1,0 +1,243 @@
+// Copyright 2019-2022 Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A pallet to put your incoming XCM execution into a restricted emergency or safe mode automatically.
+
+#![allow(non_camel_case_types)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+use cumulus_pallet_parachain_system::CheckAssociatedRelayNumber;
+use frame_support::pallet;
+use frame_support::pallet_prelude::*;
+use frame_support::traits::{ProcessMessage, QueuePausedQuery};
+use frame_system::pallet_prelude::*;
+use frame_system::RawOrigin;
+use parity_scale_codec::{Decode, Encode};
+use polkadot_parachain_primitives::primitives::{Id, RelayChainBlockNumber, XcmpMessageHandler};
+
+// TODO: move to file type.rs
+#[derive(Decode, Default, Encode, PartialEq, TypeInfo)]
+pub enum XcmMode {
+	#[default]
+	Normal,
+	Limited,
+	Paused,
+}
+
+#[pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	/// Configuration trait of this pallet.
+	#[pallet::config]
+	pub trait Config:
+		frame_system::Config
+		+ cumulus_pallet_parachain_system::Config<
+			CheckAssociatedRelayNumber = Pallet<Self>,
+			XcmpMessageHandler = Pallet<Self>,
+		> + pallet_message_queue::Config<QueuePausedQuery = Pallet<Self>>
+	{
+		/// Overarching event type
+		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// TODO doc
+		type CheckAssociatedRelayNumber: CheckAssociatedRelayNumber;
+
+		/// TODO doc
+		type QueuePausedQuery: QueuePausedQuery<<Self::MessageProcessor as ProcessMessage>::Origin>;
+
+		/// The HRMP handler to be used in normal operating mode
+		type HrmpMessageHandler: XcmpMessageHandler;
+
+		/// Allow to apply a lower Weight Limit for DMP messages where block production seem's stall
+		type LimitedModeDmpWeightLimit: Get<Weight>;
+
+		/// Allow to apply a lower Weight Limit for HRMP messages where block production seem's stall
+		type LimitedModeHrmpWeightLimit: Get<Weight>;
+
+		/// Maximum number of relay block to skip before trigering the Limited mode.
+		/// Note that if both Limited and Paused threshold are reach, the Paused mode will be apply.
+		type LimitedThreshold: Get<RelayChainBlockNumber>;
+
+		/// Maximum number of relay block to skip before trigering the Paused mode.
+		type PausedThreshold: Get<RelayChainBlockNumber>;
+
+		/// Origin allowed to perform a fast authorize upgrade when XcmMode is not normal
+		type FastAuthorizeUpgradeOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// Origin allowed to resume from limited mode
+		type LimitedToNormalOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// origin allowed to resume to normal operations from paused mode
+		type PausedToNormalOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// origin alllowed to change Paused mode to Limited
+		type PausedToLimitedOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
+	pub enum Event {
+		/// The xcm mode was put into Limited Mode
+		EnteredLimitedXcmMode,
+		// The xcm incoming execution was Paused
+		EnteredPausedXcmMode,
+		/// The XCm incoming execution returned to normal operations
+		NormalXcmOperationResumed,
+	}
+
+	/// An error that can occur while executing this pallet's extrinsics.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Fast authorize upgrade is forbiden in normal mode
+		NotInLimitedOrPausedMode,
+		/// The current XCM Mode is not Limited
+		NotInLimitedMode,
+		/// The current XCM Mode is not Paused
+		NotInPausedMode,
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn mode)]
+	/// Whether incoming XCM is enabled, limited or paused
+	pub type Mode<T: Config> = StorageValue<_, XcmMode, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+			// Account for 1 read and 1 write to `Mode`
+			T::DbWeight::get().reads_writes(1, 1)
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight((0, DispatchClass::Operational))]
+		pub fn limited_to_normal(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			T::LimitedToNormalOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				Mode::<T>::get() == XcmMode::Limited,
+				Error::<T>::NotInLimitedMode
+			);
+
+			Mode::<T>::set(XcmMode::Normal);
+			<Pallet<T>>::deposit_event(Event::NormalXcmOperationResumed);
+
+			Ok(().into())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight((0, DispatchClass::Operational))]
+		pub fn paused_to_normal(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			T::PausedToNormalOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				Mode::<T>::get() == XcmMode::Paused,
+				Error::<T>::NotInPausedMode
+			);
+
+			Mode::<T>::set(XcmMode::Normal);
+			<Pallet<T>>::deposit_event(Event::NormalXcmOperationResumed);
+
+			Ok(().into())
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight((0, DispatchClass::Operational))]
+		pub fn paused_to_limited(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			T::PausedToLimitedOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				Mode::<T>::get() == XcmMode::Paused,
+				Error::<T>::NotInPausedMode
+			);
+
+			Mode::<T>::set(XcmMode::Limited);
+			<Pallet<T>>::deposit_event(Event::EnteredLimitedXcmMode);
+
+			Ok(().into())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight((1_000_000, DispatchClass::Operational))]
+		pub fn fast_authorize_upgrade(
+			origin: OriginFor<T>,
+			code_hash: T::Hash,
+		) -> DispatchResult {
+			T::FastAuthorizeUpgradeOrigin::ensure_origin(origin)?;
+			ensure!(
+				Mode::<T>::get() != XcmMode::Normal,
+				Error::<T>::NotInLimitedOrPausedMode
+			);
+
+			frame_system::Pallet::<T>::authorize_upgrade(RawOrigin::Root.into(), code_hash)
+		}
+	}
+}
+
+impl<T: Config> CheckAssociatedRelayNumber for Pallet<T> {
+	fn check_associated_relay_number(
+		current: RelayChainBlockNumber,
+		previous: RelayChainBlockNumber,
+	) {
+		<T as Config>::CheckAssociatedRelayNumber::check_associated_relay_number(current, previous);
+
+		if current > previous + T::PausedThreshold::get() {
+			Mode::<T>::set(XcmMode::Paused);
+			<Pallet<T>>::deposit_event(Event::EnteredPausedXcmMode);
+		} else if current > previous + T::LimitedThreshold::get() {
+			Mode::<T>::set(XcmMode::Limited);
+			<Pallet<T>>::deposit_event(Event::EnteredLimitedXcmMode);
+		}
+	}
+}
+
+impl<T: Config> XcmpMessageHandler for Pallet<T> {
+	fn handle_xcmp_messages<'a, I: Iterator<Item = (Id, RelayChainBlockNumber, &'a [u8])>>(
+		iter: I,
+		limit: Weight,
+	) -> Weight {
+		match Mode::<T>::get() {
+			XcmMode::Normal => T::HrmpMessageHandler::handle_xcmp_messages(iter, limit),
+			XcmMode::Limited => T::HrmpMessageHandler::handle_xcmp_messages(
+				iter,
+				T::LimitedModeHrmpWeightLimit::get(),
+			),
+			XcmMode::Paused => T::HrmpMessageHandler::handle_xcmp_messages(iter, Weight::zero()),
+		}
+	}
+}
+
+impl<T> QueuePausedQuery<<T::MessageProcessor as ProcessMessage>::Origin> for Pallet<T>
+where
+	T: Config,
+{
+	fn is_paused(origin: &<T::MessageProcessor as ProcessMessage>::Origin) -> bool {
+		if Mode::<T>::get() == XcmMode::Normal {
+			<T as Config>::QueuePausedQuery::is_paused(origin)
+		} else {
+			true
+		}
+	}
+}

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -155,7 +155,7 @@ pub mod pallet {
 
 		/// Authorize a runtime upgrade. Only callable in `Paused` mode
 		#[pallet::call_index(1)]
-		#[pallet::weight((T::DbWeight::get().read, DispatchClass::Operational))]
+		#[pallet::weight((T::SystemWeightInfo::authorize_upgrade().saturating_add(T::DbWeight::get().read), DispatchClass::Operational))]
 		pub fn fast_authorize_upgrade(origin: OriginFor<T>, code_hash: T::Hash) -> DispatchResult {
 			T::FastAuthorizeUpgradeOrigin::ensure_origin(origin)?;
 			ensure!(

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -93,8 +93,8 @@ pub mod pallet {
 		/// what would be passed to `pallet_message_queue` if this pallet was not being used.
 		type QueuePausedQuery: QueuePausedQuery<<Self::MessageProcessor as ProcessMessage>::Origin>;
 
-		/// The HRMP handler to be used in normal operating mode
-		type HrmpMessageHandler: XcmpMessageHandler;
+		/// The XCMP handler to be used in normal operating mode
+		type XcmpMessageHandler: XcmpMessageHandler;
 
 		/// Maximum number of relay block to skip before trigering the Paused mode.
 		type PausedThreshold: Get<RelayChainBlockNumber>;
@@ -188,8 +188,10 @@ impl<T: Config> XcmpMessageHandler for Pallet<T> {
 		limit: Weight,
 	) -> Weight {
 		match Mode::<T>::get() {
-			XcmMode::Normal => T::HrmpMessageHandler::handle_xcmp_messages(iter, limit),
-			XcmMode::Paused => T::HrmpMessageHandler::handle_xcmp_messages(iter, Weight::zero()),
+			XcmMode::Normal => <T as Config>::XcmpMessageHandler::handle_xcmp_messages(iter, limit),
+			XcmMode::Paused => {
+				<T as Config>::XcmpMessageHandler::handle_xcmp_messages(iter, Weight::zero())
+			}
 		}
 	}
 }

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -130,6 +130,7 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
 			// Account for 1 read and 1 write to `Mode`
+			// during `check_associated_relay_number`
 			T::DbWeight::get().reads_writes(1, 1)
 		}
 	}

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -101,7 +101,6 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn mode)]
 	/// Whether incoming XCM is enabled or paused
 	pub type Mode<T: Config> = StorageValue<_, XcmMode, ValueQuery>;
 

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -50,7 +50,7 @@ use frame_support::pallet;
 use frame_support::pallet_prelude::*;
 use frame_support::traits::{ProcessMessage, QueuePausedQuery};
 use frame_system::pallet_prelude::*;
-use frame_system::RawOrigin;
+use frame_system::{RawOrigin, WeightInfo};
 use parity_scale_codec::{Decode, Encode};
 use polkadot_parachain_primitives::primitives::{Id, RelayChainBlockNumber, XcmpMessageHandler};
 
@@ -156,7 +156,7 @@ pub mod pallet {
 
 		/// Authorize a runtime upgrade. Only callable in `Paused` mode
 		#[pallet::call_index(1)]
-		#[pallet::weight((T::SystemWeightInfo::authorize_upgrade().saturating_add(T::DbWeight::get().read), DispatchClass::Operational))]
+		#[pallet::weight((T::SystemWeightInfo::authorize_upgrade().saturating_add(T::DbWeight::get().read.into()), DispatchClass::Operational))]
 		pub fn fast_authorize_upgrade(origin: OriginFor<T>, code_hash: T::Hash) -> DispatchResult {
 			T::FastAuthorizeUpgradeOrigin::ensure_origin(origin)?;
 			ensure!(

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -19,6 +19,11 @@
 #![allow(non_camel_case_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 pub use pallet::*;
 
 use cumulus_pallet_parachain_system::CheckAssociatedRelayNumber;
@@ -58,10 +63,12 @@ pub mod pallet {
 		/// Overarching event type
 		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// TODO doc
+		/// Used before check associated relay block number. It should be what would be passed to
+		/// `cumulus_pallet_parachain_system` if this pallet was not being used.
 		type CheckAssociatedRelayNumber: CheckAssociatedRelayNumber;
 
-		/// TODO doc
+		/// Used to check wether message queue is paused when `XcmMode` is `Normal`. It should be
+		/// what would be passed to `pallet_message_queue` if this pallet was not being used.
 		type QueuePausedQuery: QueuePausedQuery<<Self::MessageProcessor as ProcessMessage>::Origin>;
 
 		/// The HRMP handler to be used in normal operating mode

--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -61,7 +61,7 @@ pub enum XcmMode {
 	#[default]
 	Normal,
 	/// Paused: no XCM messages are processed and `FastAuthorizedUpgrade`
-	/// origin can authorized a runtime upgrade
+	/// origin can authorize a runtime upgrade
 	Paused,
 }
 

--- a/pallets/emergency-para-xcm/src/mock.rs
+++ b/pallets/emergency-para-xcm/src/mock.rs
@@ -90,6 +90,7 @@ impl cumulus_pallet_parachain_system::Config for Test {
 	type ReservedDmpWeight = ();
 	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type WeightInfo = ();
+	type ConsensusHook = cumulus_pallet_parachain_system::ExpectParentIncluded;
 }
 
 parameter_types! {
@@ -117,7 +118,7 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
 	type QueuePausedQuery = ();
-	type HrmpMessageHandler = JustConsumeAllWeight;
+	type XcmpMessageHandler = JustConsumeAllWeight;
 	type PausedThreshold = ConstU32<PAUSED_THRESHOLD>;
 	type FastAuthorizeUpgradeOrigin = EnsureRoot<AccountId>;
 	type PausedToNormalOrigin = EnsureRoot<AccountId>;

--- a/pallets/emergency-para-xcm/src/mock.rs
+++ b/pallets/emergency-para-xcm/src/mock.rs
@@ -1,0 +1,195 @@
+// Copyright Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use crate as pallet_emergency_para_xcm;
+use cumulus_pallet_parachain_system::{CheckAssociatedRelayNumber, ParachainSetCode};
+use cumulus_primitives_core::{
+	relay_chain::BlockNumber as RelayBlockNumber, AggregateMessageOrigin, InboundDownwardMessage,
+	InboundHrmpMessage, ParaId, PersistedValidationData,
+};
+use frame_support::parameter_types;
+use frame_support::traits::{ConstU32, ProcessMessage, ProcessMessageError};
+use frame_support::weights::{RuntimeDbWeight, Weight, WeightMeter};
+use frame_system::EnsureRoot;
+use sp_core::H256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use std::cell::RefCell;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Storage, Inherent, Event<T>, Config<T>},
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},
+		EmergencyParaXcm: pallet_emergency_para_xcm::{Pallet, Call, Storage, Event},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+pub type AccountId = u64;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Block = Block;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ParachainSetCode<Self>;
+	type MaxConsumers = ConstU32<16>;
+	type RuntimeTask = ();
+}
+
+parameter_types! {
+	pub ParachainId: ParaId = 100.into();
+	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
+}
+
+impl cumulus_pallet_parachain_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type SelfParaId = ParachainId;
+	type OnSystemEvent = ();
+	type OutboundXcmpMessageSource = ();
+	type XcmpMessageHandler = EmergencyParaXcm;
+	type ReservedXcmpWeight = ();
+	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
+	type ReservedDmpWeight = ();
+	type CheckAssociatedRelayNumber = EmergencyParaXcm;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const MessageQueueMaxStale: u32 = 8;
+	pub const MessageQueueHeapSize: u32 = 64 * 1024;
+	pub const MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_message_queue::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type MessageProcessor = SaveIntoThreadLocal;
+	type Size = u32;
+	type HeapSize = MessageQueueHeapSize;
+	type MaxStale = MessageQueueMaxStale;
+	type ServiceWeight = MaxWeight;
+	type QueueChangeHandler = ();
+	type QueuePausedQuery = EmergencyParaXcm;
+	type WeightInfo = ();
+}
+
+pub(crate) const PAUSED_THRESHOLD: u32 = 5;
+
+impl Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
+	type QueuePausedQuery = ();
+	type HrmpMessageHandler = ();
+	type PausedThreshold = ConstU32<PAUSED_THRESHOLD>;
+	type FastAuthorizeUpgradeOrigin = EnsureRoot<AccountId>;
+	type PausedToNormalOrigin = EnsureRoot<AccountId>;
+}
+
+// A `MessageProcessor` that stores all messages in thread-local.
+// taken from https://github.com/paritytech/polkadot-sdk/blob/3c6ebd9e9bfda58f199cba6ec3023e0d12d6b506/cumulus/pallets/parachain-system/src/mock.rs#L132
+pub struct SaveIntoThreadLocal;
+
+std::thread_local! {
+	pub static HANDLED_DMP_MESSAGES: RefCell<Vec<Vec<u8>>> = RefCell::new(Vec::new());
+	pub static HANDLED_XCMP_MESSAGES: RefCell<Vec<(ParaId, RelayChainBlockNumber, Vec<u8>)>> = RefCell::new(Vec::new());
+}
+
+impl ProcessMessage for SaveIntoThreadLocal {
+	type Origin = AggregateMessageOrigin;
+
+	fn process_message(
+		message: &[u8],
+		origin: Self::Origin,
+		_meter: &mut WeightMeter,
+		_id: &mut [u8; 32],
+	) -> Result<bool, ProcessMessageError> {
+		assert_eq!(origin, Self::Origin::Parent);
+
+		HANDLED_DMP_MESSAGES.with(|m| {
+			m.borrow_mut().push(message.to_vec());
+			Weight::zero()
+		});
+		Ok(true)
+	}
+}
+
+impl XcmpMessageHandler for SaveIntoThreadLocal {
+	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
+		iter: I,
+		_max_weight: Weight,
+	) -> Weight {
+		HANDLED_XCMP_MESSAGES.with(|m| {
+			for (sender, sent_at, message) in iter {
+				m.borrow_mut().push((sender, sent_at, message.to_vec()));
+			}
+			Weight::zero()
+		})
+	}
+}
+
+pub(crate) struct ExtBuilder;
+
+impl ExtBuilder {
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut storage = frame_system::GenesisConfig::<Test>::default()
+			.build_storage()
+			.expect("Frame system builds valid default genesis config");
+
+		let mut ext = sp_io::TestExternalities::new(storage);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub(crate) fn events() -> Vec<pallet_emergency_para_xcm::Event> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| {
+			if let RuntimeEvent::EmergencyParaXcm(inner) = e {
+				Some(inner)
+			} else {
+				None
+			}
+		})
+		.collect::<Vec<_>>()
+}

--- a/pallets/emergency-para-xcm/src/tests.rs
+++ b/pallets/emergency-para-xcm/src/tests.rs
@@ -1,0 +1,76 @@
+// Copyright Moonsong Labs
+// This file is part of Moonkit.
+
+// Moonkit is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonkit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+use crate::mock::*;
+use crate::*;
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::traits::Dispatchable;
+
+#[test]
+fn remains_in_normal_mode_when_relay_block_diff_is_within_threshold() {
+	ExtBuilder {}.build().execute_with(|| {
+		let current_block = 1;
+		let new_block = PAUSED_THRESHOLD + current_block;
+		EmergencyParaXcm::check_associated_relay_number(new_block, current_block);
+		let xcm_mode = EmergencyParaXcm::mode();
+		assert!(xcm_mode == XcmMode::Normal);
+	})
+}
+
+#[test]
+fn pauses_xcm_when_relay_block_diff_is_above_threshold() {
+	ExtBuilder {}.build().execute_with(|| {
+		let current_block = 1;
+		let new_block = PAUSED_THRESHOLD + current_block + 1;
+		EmergencyParaXcm::check_associated_relay_number(new_block, current_block);
+		let xcm_mode = EmergencyParaXcm::mode();
+		assert!(xcm_mode == XcmMode::Paused);
+		assert_eq!(events(), vec![Event::EnteredPausedXcmMode,]);
+	})
+}
+
+#[test]
+fn cannot_go_from_paused_to_normal_with_wrong_origin() {
+	ExtBuilder {}.build().execute_with(|| {
+		Mode::<Test>::set(XcmMode::Paused);
+		let call: RuntimeCall = Call::paused_to_normal {}.into();
+		assert_noop!(
+			call.dispatch(RuntimeOrigin::signed(1)),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn cannot_go_from_paused_to_normal_when_not_paused() {
+	ExtBuilder {}.build().execute_with(|| {
+		let call: RuntimeCall = Call::paused_to_normal {}.into();
+		assert_noop!(
+			call.dispatch(RuntimeOrigin::root()),
+			Error::<Test>::NotInPausedMode
+		);
+	});
+}
+
+#[test]
+fn can_go_from_paused_to_normal() {
+	ExtBuilder {}.build().execute_with(|| {
+		Mode::<Test>::set(XcmMode::Paused);
+		let call: RuntimeCall = Call::paused_to_normal {}.into();
+		assert_ok!(call.dispatch(RuntimeOrigin::root()));
+		let xcm_mode = EmergencyParaXcm::mode();
+		assert!(xcm_mode == XcmMode::Normal);
+	});
+}


### PR DESCRIPTION
Adds a pallet to automatically pause the execution (but not the en-queuing) of xcm messages whenever the chain has not produced a block for a given amount of relay chain blocks. There's the option to give an origin the ability to perform a runtime update whenever this "paused" mode is entered.