### PR TITLE
Do not pause xcm if previous block is 0

### DIFF
--- a/pallets/emergency-para-xcm/src/lib.rs
+++ b/pallets/emergency-para-xcm/src/lib.rs
@@ -176,7 +176,7 @@ impl<T: Config> CheckAssociatedRelayNumber for Pallet<T> {
 	) {
 		<T as Config>::CheckAssociatedRelayNumber::check_associated_relay_number(current, previous);
 
-		if current > previous + T::PausedThreshold::get() {
+		if (previous != 0) && (current > (previous + T::PausedThreshold::get())) {
 			Mode::<T>::set(XcmMode::Paused);
 			<Pallet<T>>::deposit_event(Event::EnteredPausedXcmMode);
 		}

--- a/pallets/emergency-para-xcm/src/tests.rs
+++ b/pallets/emergency-para-xcm/src/tests.rs
@@ -23,9 +23,20 @@ use sp_runtime::traits::Dispatchable;
 #[test]
 fn remains_in_normal_mode_when_relay_block_diff_is_within_threshold() {
 	new_test_ext().execute_with(|| {
-		let current_block = 1;
-		let new_block = PAUSED_THRESHOLD + current_block;
-		EmergencyParaXcm::check_associated_relay_number(new_block, current_block);
+		let previous_block = 1;
+		let current_block = PAUSED_THRESHOLD + previous_block;
+		EmergencyParaXcm::check_associated_relay_number(current_block, previous_block);
+		let xcm_mode = Mode::<Test>::get();
+		assert!(xcm_mode == XcmMode::Normal);
+	})
+}
+
+#[test]
+fn remains_in_normal_mode_if_previous_relay_block_is_0() {
+	new_test_ext().execute_with(|| {
+		let previous_block = 0;
+		let current_block = PAUSED_THRESHOLD + previous_block + 1;
+		EmergencyParaXcm::check_associated_relay_number(current_block, previous_block);
 		let xcm_mode = Mode::<Test>::get();
 		assert!(xcm_mode == XcmMode::Normal);
 	})
@@ -34,9 +45,9 @@ fn remains_in_normal_mode_when_relay_block_diff_is_within_threshold() {
 #[test]
 fn pauses_xcm_when_relay_block_diff_is_above_threshold() {
 	new_test_ext().execute_with(|| {
-		let current_block = 1;
-		let new_block = PAUSED_THRESHOLD + current_block + 1;
-		EmergencyParaXcm::check_associated_relay_number(new_block, current_block);
+		let previous_block = 1;
+		let current_block = PAUSED_THRESHOLD + previous_block + 1;
+		EmergencyParaXcm::check_associated_relay_number(current_block, previous_block);
 		let xcm_mode = Mode::<Test>::get();
 		assert!(xcm_mode == XcmMode::Paused);
 		assert_eq!(events(), vec![Event::EnteredPausedXcmMode,]);


### PR DESCRIPTION
This prevents a paused xcm mode triggering on first block on a parachain