### PR TITLE
benchmarks(pallet-author-mapping, pallet-randomness): account existential deposit in benchmarks

### DIFF
--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, optional = true }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+pallet-balances = { workspace = true, optional = true }
 parity-scale-codec = { workspace = true, features = [ "derive" ] }
 scale-info = { workspace = true, features = [ "derive" ] }
 sp-runtime = { workspace = true }
@@ -27,7 +28,6 @@ sp-std = { workspace = true }
 session-keys-primitives = { workspace = true }
 
 [dev-dependencies]
-pallet-balances = { workspace = true, features = ["std"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 
@@ -45,9 +45,11 @@ std = [
 	"session-keys-primitives/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"pallet-balances/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
+	"pallet-balances",
 	"session-keys-primitives/runtime-benchmarks",
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -24,13 +24,13 @@ sp-consensus-babe = { workspace = true }
 
 # Benchmarks
 frame-benchmarking = { workspace = true, optional = true }
+pallet-balances = { workspace = true, optional = true, features = [ "insecure_zero_ed" ] }
 hex = { workspace = true }
 
 
 [dev-dependencies]
 derive_more = { workspace = true }
 pallet-author-mapping = { workspace = true, features = [ "std" ] }
-pallet-balances = { workspace = true, features = [ "std", "insecure_zero_ed" ] }
 
 [features]
 default = [ "std" ]
@@ -49,10 +49,12 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"schnorrkel/std"
+	"schnorrkel/std",
+	"pallet-balances/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
+	"pallet-balances",
 	"session-keys-primitives/runtime-benchmarks",
 ]
 try-runtime = [ "frame-support/try-runtime" ]


### PR DESCRIPTION
Account for `ExistentialDeposit` when funding an account in benchmarks for `pallet-author-mapping` and `pallet-randomness`.  This is necessary because `pallet-xcm` benchmarks forces the runtime to use a non-zero `ExistentialDeposit` and as consequence `pallet-author-mapping` and `pallet-randomness` benchmarks started to fail.