### PR TITLE
Improve `Erc20PalletMatcher`

### DIFF
--- a/precompiles/pallet-xcm/src/mock.rs
+++ b/precompiles/pallet-xcm/src/mock.rs
@@ -40,7 +40,7 @@ use xcm_executor::{
 	AssetsInHolding,
 };
 pub use xcm_primitives::{
-	location_matcher::{Erc20PalletMatcher, ForeignAssetMatcher, SingleAddressMatcher},
+	location_matcher::{ForeignAssetMatcher, SingleAddressMatcher},
 	AccountIdAssetIdConversion,
 };
 use Junctions::Here;
@@ -211,10 +211,7 @@ pub type SingleAddressMatch = SingleAddressMatcher<AccountIdAlias, 2050, Balance
 pub type ForeignAssetMatch =
 	ForeignAssetMatcher<AccountIdAlias, AssetId, mock::Runtime, ForeignAssetCreator>;
 
-pub type Erc20Match = Erc20PalletMatcher<AccountIdAlias, 42>;
-
-pub type PCall =
-	PalletXcmPrecompileCall<Runtime, (SingleAddressMatch, ForeignAssetMatch, Erc20Match)>;
+pub type PCall = PalletXcmPrecompileCall<Runtime, (SingleAddressMatch, ForeignAssetMatch)>;
 
 mock_account!(ParentAccount, |_| MockAccount::from_u64(4));
 
@@ -230,7 +227,7 @@ const BLOCK_STORAGE_LIMIT: u64 = 40 * 1024;
 
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::from(u64::MAX);
-	pub PrecompilesValue: Precompiles<Runtime, (SingleAddressMatch, ForeignAssetMatch, Erc20Match)> = Precompiles::new();
+	pub PrecompilesValue: Precompiles<Runtime, (SingleAddressMatch, ForeignAssetMatch)> = Precompiles::new();
 	pub const WeightPerGas: Weight = Weight::from_parts(1, 0);
 	pub GasLimitPovSizeRatio: u64 = {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
@@ -265,7 +262,7 @@ impl pallet_evm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type PrecompilesValue = PrecompilesValue;
-	type PrecompilesType = Precompiles<Self, (SingleAddressMatch, ForeignAssetMatch, Erc20Match)>;
+	type PrecompilesType = Precompiles<Self, (SingleAddressMatch, ForeignAssetMatch)>;
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -22,7 +22,7 @@ use sp_core::{H160, H256};
 use sp_weights::Weight;
 use xcm::latest::Junction::*;
 
-fn precompiles() -> Precompiles<Runtime, (SingleAddressMatch, ForeignAssetMatch, Erc20Match)> {
+fn precompiles() -> Precompiles<Runtime, (SingleAddressMatch, ForeignAssetMatch)> {
 	PrecompilesValue::get()
 }
 

--- a/primitives/xcm/src/location_matcher.rs
+++ b/primitives/xcm/src/location_matcher.rs
@@ -93,19 +93,20 @@ where
 }
 
 // Matcher for any pallet that handles ERC20s internally.
-pub struct Erc20PalletMatcher<AccountId, const PALLET_INDEX: u8>(PhantomData<AccountId>);
+pub struct Erc20PalletMatcher<AccountId, PalletInstance>(PhantomData<(AccountId, PalletInstance)>);
 
-impl<AccountId, const PALLET_INDEX: u8> AccountIdToLocationMatcher<AccountId>
-	for Erc20PalletMatcher<AccountId, PALLET_INDEX>
+impl<AccountId, PalletInstance> AccountIdToLocationMatcher<AccountId>
+	for Erc20PalletMatcher<AccountId, PalletInstance>
 where
 	AccountId: Parameter + Into<H160>,
+	PalletInstance: PalletInfoAccess,
 {
 	fn convert(account: AccountId) -> Option<Location> {
 		let h160_account = account.into();
 		Some(Location::new(
 			0,
 			[
-				PalletInstance(PALLET_INDEX),
+				PalletInstance(<PalletInstance as PalletInfoAccess>::index() as u8),
 				AccountKey20 {
 					key: h160_account.0,
 					network: None,


### PR DESCRIPTION
This PR improves the way in which  `Erc20PalletMatcher` receives the pallet index. Previously, it was receiving a plain const, and with these changes it now receives a `PalletInstance` (as the `SingleAddressMatcher` does). 

This allows to pass a pallet and retrieve the pallet index from there, without the need of manually specifying the const in the implementation, which could be more error prone.