### PR TITLE
add primtiive types with byteorder to xcm-primtives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16147,6 +16147,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
+ "primitive-types",
  "sp-core",
  "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.11.0)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ paste = "1.0.14"
 slices = "0.2.0"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
+primitive-types = { version = "0.12.2", default-features = false }
 
 # Crates.io (template only)
 clap = { version = "4.0.9" }

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -15,6 +15,8 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "derive" ] }
 xcm = { workspace = true }
+# needed for H160_from_low_u64_be as sp-core does not add this feature
+primitive-types = { workspace = true, featues = ["byteorder"] }
 
 [features]
 default = [ "std" ]
@@ -24,6 +26,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"parity-scale-codec/std",
+	"primitive-types/std",
 	"xcm/std"
 ]
 runtime-benchmarks = []


### PR DESCRIPTION
Adds primitive-types to xcm-primtiives, as otherwise the `from_low_u64_be` cannot be performed in the location matcher. This specially hits for runtimes that do not incorporate this  `primitive-types` with the byteorder feature from other dependencies, like dancebox. 

In contrast, moonbeam & frontier do not suffer from this as `primitive-types` is incorporated with byteorder through `evm` and `ethereum-types` crates