### PR TITLE
Add support for `transfer_assets_using_type_and_then` extrinsic in pallet-xcm precompile

### DIFF
--- a/pallets/emergency-para-xcm/src/mock.rs
+++ b/pallets/emergency-para-xcm/src/mock.rs
@@ -19,6 +19,7 @@ use crate as pallet_emergency_para_xcm;
 use cumulus_pallet_parachain_system::ParachainSetCode;
 use cumulus_primitives_core::{
 	relay_chain::BlockNumber as RelayBlockNumber, AggregateMessageOrigin, ParaId,
+	XcmpMessageHandler,
 };
 use frame_support::parameter_types;
 use frame_support::traits::ConstU32;

--- a/precompiles/pallet-xcm/Cargo.toml
+++ b/precompiles/pallet-xcm/Cargo.toml
@@ -16,10 +16,12 @@ xcm-primitives = { workspace = true }
 # Substrate
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-weights = { workspace = true }
+parity-scale-codec = { workspace = true, features = [ "derive" ] }
 
 # Frontier
 evm = { workspace = true, features = [ "with-codec" ] }
@@ -28,6 +30,7 @@ pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
 
 # Polkadot
 xcm = { workspace = true }
+xcm-executor = { workspace = true }
 pallet-xcm = { workspace = true }
 
 # Cumulus
@@ -61,7 +64,9 @@ std = [
 	"frame-system/std",
 	"pallet-evm/std",
     "pallet-xcm/std",
+	"parity-scale-codec/std",
 	"precompile-utils/std",
+	"scale-info/std",
 	"sp-core/std",
 	"sp-std/std",
 	"xcm/std",

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -100,7 +100,7 @@ interface XCM {
     /// @param assetsTransferType The TransferType corresponding to assets being sent.
     /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
     /// @param feesTransferType The TransferType corresponding to the asset used as fees.
-    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param customXcmOnDest The XCM message to execute on destination chain (SCALE encoded).
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
@@ -116,7 +116,7 @@ interface XCM {
     /// @param dest The destination chain.
     /// @param assets The combination (array) of assets to send in Location format.
     /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
-    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param customXcmOnDest The XCM message to execute on destination chain (SCALE encoded).
     /// @param remoteReserve The remote reserve corresponding for assets and fees. They MUST
     /// share the same reserve.
     function transferAssetsUsingTypeAndThenLocation(
@@ -138,7 +138,7 @@ interface XCM {
     /// @param assetsTransferType The TransferType corresponding to assets being sent.
     /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
     /// @param feesTransferType The TransferType corresponding to the asset used as fees.
-    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param customXcmOnDest The XCM message to execute on destination chain (SCALE encoded).
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,
@@ -154,7 +154,7 @@ interface XCM {
     /// @param dest The destination chain.
     /// @param assets The combination (array) of assets to send in Address format.
     /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
-    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param customXcmOnDest The XCM message to execute on destination chain (SCALE encoded).
     /// @param remoteReserve The remote reserve corresponding for assets and fees. They MUST
     /// share the same reserve.
     function transferAssetsUsingTypeAndThenAddress(

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -40,7 +40,7 @@ interface XCM {
     /// @custom:selector 9ea8ada7
     /// @param dest The destination chain.
     /// @param beneficiary The actual account that will receive the tokens on dest.
-    /// @param assets The combination (array) of assets to send.
+    /// @param assets The combination (array) of assets to send in Location format.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
     function transferAssetsLocation(
         Location memory dest,
@@ -54,7 +54,7 @@ interface XCM {
     /// @custom:selector a0aeb5fe
     /// @param paraId The para-id of the destination chain.
     /// @param beneficiary The actual account that will receive the tokens on paraId destination.
-    /// @param assets The combination (array) of assets to send.
+    /// @param assets The combination (array) of assets to send in Address format.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
     function transferAssetsToPara20(
         uint32 paraId,
@@ -68,7 +68,7 @@ interface XCM {
     /// @custom:selector f23032c3
     /// @param paraId The para-id of the destination chain.
     /// @param beneficiary The actual account that will receive the tokens on paraId destination.
-    /// @param assets The combination (array) of assets to send.
+    /// @param assets The combination (array) of assets to send in Address format.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
     function transferAssetsToPara32(
         uint32 paraId,
@@ -81,7 +81,7 @@ interface XCM {
     /// using transfer_assets() pallet-xcm extrinsic.
     /// @custom:selector 6521cc2c
     /// @param beneficiary The actual account that will receive the tokens on the relay chain.
-    /// @param assets The combination (array) of assets to send.
+    /// @param assets The combination (array) of assets to send in Address format.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
     function transferAssetsToRelay(
         bytes32 beneficiary,
@@ -89,7 +89,18 @@ interface XCM {
         uint32 feeAssetItem
     ) external;
 
-    // No RemoteReserve at all
+    /// @dev Function to send assets through transfer_assets_using_type_and_then() pallet-xcm
+    /// extrinsic.
+    /// Important: in this selector RemoteReserve type (for either assets or fees) is not allowed.
+    /// If users want to send assets and fees (in Location format) with a remote reserve, 
+    /// they must use the selector fc19376c.
+    /// @custom:selector 8425d893
+    /// @param dest The destination chain.
+    /// @param assets The combination (array) of assets to send in Location format.
+    /// @param assetsTransferType The TransferType corresponding to assets being sent.
+    /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
+    /// @param feesTransferType The TransferType corresponding to the asset used as fees.
+    /// @param customXcmOnDest The XCM message to execute on destination chain.
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
@@ -99,7 +110,15 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Remote reserve for assets and fees (must share same remote reserve)
+    /// @dev Function to send assets through transfer_assets_using_type_and_then() pallet-xcm
+    /// extrinsic.
+    /// @custom:selector fc19376c
+    /// @param dest The destination chain.
+    /// @param assets The combination (array) of assets to send in Location format.
+    /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
+    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param remoteReserve The remote reserve corresponding for assets and fees. They MUST
+    /// share the same reserve.
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
@@ -108,7 +127,18 @@ interface XCM {
         Location memory remoteReserve
     ) external;
 
-    // No RemoteReserve at all
+    /// @dev Function to send assets through transfer_assets_using_type_and_then() pallet-xcm
+    /// extrinsic.
+    /// Important: in this selector RemoteReserve type (for either assets or fees) is not allowed.
+    /// If users want to send assets and fees (in Address format) with a remote reserve, 
+    /// they must use the selector aaecfc62.
+    /// @custom:selector 998093ee
+    /// @param dest The destination chain.
+    /// @param assets The combination (array) of assets to send in Address format.
+    /// @param assetsTransferType The TransferType corresponding to assets being sent.
+    /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
+    /// @param feesTransferType The TransferType corresponding to the asset used as fees.
+    /// @param customXcmOnDest The XCM message to execute on destination chain.
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,
@@ -118,7 +148,15 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Remote reserve for assets and fees (must share same reserve)
+    /// @dev Function to send assets through transfer_assets_using_type_and_then() pallet-xcm
+    /// extrinsic.
+    /// @custom:selector aaecfc62
+    /// @param dest The destination chain.
+    /// @param assets The combination (array) of assets to send in Address format.
+    /// @param remoteFeesIdIndex The index of the asset (inside assets array) to use as fees.
+    /// @param customXcmOnDest The XCM message to execute on destination chain.
+    /// @param remoteReserve The remote reserve corresponding for assets and fees. They MUST
+    /// share the same reserve.
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -33,8 +33,7 @@ interface XCM {
     enum TransferType {
         Teleport,
         LocalReserve,
-        DestinationReserve,
-        RemoteReserve
+        DestinationReserve
     }
 
     /// @dev Function to send assets via XCM using transfer_assets() pallet-xcm extrinsic.
@@ -100,7 +99,7 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Reserve for assets and fees (must share same reserve if the transfer type is RemoteReserve)
+    // Remote reserve for assets and fees (must share same remote reserve)
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
@@ -119,7 +118,7 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Reserve for assets and fees (must share same reserve if the transfer type is RemoteReserve)
+    // Remote reserve for assets and fees (must share same reserve)
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -38,68 +38,56 @@ interface XCM {
     }
 
     /// @dev Function to send assets via XCM using transfer_assets() pallet-xcm extrinsic.
-    /// @custom:selector 59df8416
+    /// @custom:selector 9ea8ada7
     /// @param dest The destination chain.
     /// @param beneficiary The actual account that will receive the tokens on dest.
     /// @param assets The combination (array) of assets to send.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
-    /// @param weight The weight to be used for the whole XCM operation.
-    /// (uint64::MAX in refTime means Unlimited weight) 
     function transferAssetsLocation(
         Location memory dest,
         Location memory beneficiary,
         AssetLocationInfo[] memory assets,
-        uint32 feeAssetItem,
-        Weight memory weight
+        uint32 feeAssetItem
     ) external;
 
     /// @dev Function to send assets via XCM to a 20 byte-like parachain 
     /// using transfer_assets() pallet-xcm extrinsic.
-    /// @custom:selector b489262e
+    /// @custom:selector a0aeb5fe
     /// @param paraId The para-id of the destination chain.
     /// @param beneficiary The actual account that will receive the tokens on paraId destination.
     /// @param assets The combination (array) of assets to send.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
-    /// @param weight The weight to be used for the whole XCM operation.
-    /// (uint64::MAX in refTime means Unlimited weight)
     function transferAssetsToPara20(
         uint32 paraId,
         address beneficiary,
         AssetAddressInfo[] memory assets,
-        uint32 feeAssetItem,
-        Weight memory weight
+        uint32 feeAssetItem
     ) external;
 
     /// @dev Function to send assets via XCM to a 32 byte-like parachain 
     /// using transfer_assets() pallet-xcm extrinsic.
-    /// @custom:selector 4461e6f5
+    /// @custom:selector f23032c3
     /// @param paraId The para-id of the destination chain.
     /// @param beneficiary The actual account that will receive the tokens on paraId destination.
     /// @param assets The combination (array) of assets to send.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
-    /// @param weight The weight to be used for the whole XCM operation.
-    /// (uint64::MAX in refTime means Unlimited weight)
     function transferAssetsToPara32(
         uint32 paraId,
         bytes32 beneficiary,
         AssetAddressInfo[] memory assets,
-        uint32 feeAssetItem,
-        Weight memory weight
+        uint32 feeAssetItem
     ) external;
 
     /// @dev Function to send assets via XCM to the relay chain 
     /// using transfer_assets() pallet-xcm extrinsic.
-    /// @custom:selector d7c89659
+    /// @custom:selector 6521cc2c
     /// @param beneficiary The actual account that will receive the tokens on the relay chain.
     /// @param assets The combination (array) of assets to send.
     /// @param feeAssetItem The index of the asset that will be used to pay for fees.
-    /// @param weight The weight to be used for the whole XCM operation.
-    /// (uint64::MAX in refTime means Unlimited weight)
     function transferAssetsToRelay(
         bytes32 beneficiary,
         AssetAddressInfo[] memory assets,
-        uint32 feeAssetItem,
-        Weight memory weight
+        uint32 feeAssetItem
     ) external;
 
     function transferAssetsUsingTypeAndThenLocation(
@@ -110,8 +98,7 @@ interface XCM {
         uint8 remoteFeesIdIndex,
         TransferType feesTransferType,
         Location memory maybeFeesRemoteReserve,
-        bytes memory customXcmOnDest,
-        Weight memory weight
+        bytes memory customXcmOnDest
     ) external;
 
     function transferAssetsUsingTypeAndThenAddress(
@@ -122,7 +109,6 @@ interface XCM {
         uint8 remoteFeesIdIndex,
         TransferType feesTransferType,
         Location memory maybeFeesRemoteReserve,
-        bytes memory customXcmOnDest,
-        Weight memory weight
+        bytes memory customXcmOnDest
     ) external;
 }

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -90,7 +90,7 @@ interface XCM {
         uint32 feeAssetItem
     ) external;
 
-    // No reserves at all
+    // No RemoteReserve at all
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
@@ -100,29 +100,16 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Reserve for assets or fees (specified through isAssetReserve)
-    function transferAssetsUsingTypeAndThenLocation(
-        Location memory dest,
-        AssetLocationInfo[] memory assets,
-        TransferType assetsTransferType,
-        uint8 remoteFeesIdIndex,
-        TransferType feesTransferType,
-        bytes memory customXcmOnDest,
-        Location memory assetsOrFeeRemoteReserve,
-        bool isAssetsReserve
-    ) external;
-
-    // Reserve for both assets and fees
+    // Reserve for assets and fees (must share same reserve if the transfer type is RemoteReserve)
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
         uint8 remoteFeesIdIndex,
         bytes memory customXcmOnDest,
-        Location memory assetsRemoteReserve,
-        Location memory feesRemoteReserve
+        Location memory remoteReserve
     ) external;
 
-    // No reserves at all
+    // No RemoteReserve at all
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,
@@ -132,25 +119,12 @@ interface XCM {
         bytes memory customXcmOnDest
     ) external;
 
-    // Reserve for assets or fees (specified through isAssetReserve)
-    function transferAssetsUsingTypeAndThenAddress(
-        Location memory dest,
-        AssetAddressInfo[] memory assets,
-        TransferType assetsTransferType,
-        uint8 remoteFeesIdIndex,
-        TransferType feesTransferType,
-        bytes memory customXcmOnDest,
-        Location memory assetsOrFeeRemoteReserve,
-        bool isAssetsReserve
-    ) external;
-
-    // Reserve for both assets and fees
+    // Reserve for assets and fees (must share same reserve if the transfer type is RemoteReserve)
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,
         uint8 remoteFeesIdIndex,
         bytes memory customXcmOnDest,
-        Location memory assetsRemoteReserve,
-        Location memory feesRemoteReserve
+        Location memory remoteReserve
     ) external;
 }

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -90,25 +90,67 @@ interface XCM {
         uint32 feeAssetItem
     ) external;
 
+    // No reserves at all
     function transferAssetsUsingTypeAndThenLocation(
         Location memory dest,
         AssetLocationInfo[] memory assets,
         TransferType assetsTransferType,
-        Location memory maybeAssetsRemoteReserve,
         uint8 remoteFeesIdIndex,
         TransferType feesTransferType,
-        Location memory maybeFeesRemoteReserve,
         bytes memory customXcmOnDest
     ) external;
 
+    // Reserve for assets or fees (specified through isAssetReserve)
+    function transferAssetsUsingTypeAndThenLocation(
+        Location memory dest,
+        AssetLocationInfo[] memory assets,
+        TransferType assetsTransferType,
+        uint8 remoteFeesIdIndex,
+        TransferType feesTransferType,
+        bytes memory customXcmOnDest,
+        Location memory assetsOrFeeRemoteReserve,
+        bool isAssetsReserve
+    ) external;
+
+    // Reserve for both assets and fees
+    function transferAssetsUsingTypeAndThenLocation(
+        Location memory dest,
+        AssetLocationInfo[] memory assets,
+        uint8 remoteFeesIdIndex,
+        bytes memory customXcmOnDest,
+        Location memory assetsRemoteReserve,
+        Location memory feesRemoteReserve
+    ) external;
+
+    // No reserves at all
     function transferAssetsUsingTypeAndThenAddress(
         Location memory dest,
         AssetAddressInfo[] memory assets,
         TransferType assetsTransferType,
-        Location memory maybeAssetsRemoteReserve,
         uint8 remoteFeesIdIndex,
         TransferType feesTransferType,
-        Location memory maybeFeesRemoteReserve,
         bytes memory customXcmOnDest
+    ) external;
+
+    // Reserve for assets or fees (specified through isAssetReserve)
+    function transferAssetsUsingTypeAndThenAddress(
+        Location memory dest,
+        AssetAddressInfo[] memory assets,
+        TransferType assetsTransferType,
+        uint8 remoteFeesIdIndex,
+        TransferType feesTransferType,
+        bytes memory customXcmOnDest,
+        Location memory assetsOrFeeRemoteReserve,
+        bool isAssetsReserve
+    ) external;
+
+    // Reserve for both assets and fees
+    function transferAssetsUsingTypeAndThenAddress(
+        Location memory dest,
+        AssetAddressInfo[] memory assets,
+        uint8 remoteFeesIdIndex,
+        bytes memory customXcmOnDest,
+        Location memory assetsRemoteReserve,
+        Location memory feesRemoteReserve
     ) external;
 }

--- a/precompiles/pallet-xcm/XcmInterface.sol
+++ b/precompiles/pallet-xcm/XcmInterface.sol
@@ -29,6 +29,14 @@ interface XCM {
         uint256 amount;
     }
 
+    // The values start at `0` and are represented as `uint8`
+    enum TransferType {
+        Teleport,
+        LocalReserve,
+        DestinationReserve,
+        RemoteReserve
+    }
+
     /// @dev Function to send assets via XCM using transfer_assets() pallet-xcm extrinsic.
     /// @custom:selector 59df8416
     /// @param dest The destination chain.
@@ -91,6 +99,30 @@ interface XCM {
         bytes32 beneficiary,
         AssetAddressInfo[] memory assets,
         uint32 feeAssetItem,
+        Weight memory weight
+    ) external;
+
+    function transferAssetsUsingTypeAndThenLocation(
+        Location memory dest,
+        AssetLocationInfo[] memory assets,
+        TransferType assetsTransferType,
+        Location memory maybeAssetsRemoteReserve,
+        uint8 remoteFeesIdIndex,
+        TransferType feesTransferType,
+        Location memory maybeFeesRemoteReserve,
+        bytes memory customXcmOnDest,
+        Weight memory weight
+    ) external;
+
+    function transferAssetsUsingTypeAndThenAddress(
+        Location memory dest,
+        AssetAddressInfo[] memory assets,
+        TransferType assetsTransferType,
+        Location memory maybeAssetsRemoteReserve,
+        uint8 remoteFeesIdIndex,
+        TransferType feesTransferType,
+        Location memory maybeFeesRemoteReserve,
+        bytes memory customXcmOnDest,
         Weight memory weight
     ) external;
 }

--- a/precompiles/pallet-xcm/src/lib.rs
+++ b/precompiles/pallet-xcm/src/lib.rs
@@ -240,7 +240,6 @@ where
 		Ok(())
 	}
 
-	// First selector type: no reserves at all
 	#[precompile::public(
 		"transferAssetsUsingTypeAndThenLocation(\
 		(uint8,bytes[]),\
@@ -298,7 +297,6 @@ where
 		Ok(())
 	}
 
-	// Either assets reserve or fees reserve
 	#[precompile::public(
 		"transferAssetsUsingTypeAndThenLocation(\
 		(uint8,bytes[]),\

--- a/precompiles/pallet-xcm/src/lib.rs
+++ b/precompiles/pallet-xcm/src/lib.rs
@@ -29,10 +29,8 @@ use scale_info::TypeInfo;
 use sp_core::{H256, U256};
 use sp_runtime::traits::Dispatchable;
 use sp_std::{boxed::Box, marker::PhantomData, vec, vec::Vec};
-use sp_weights::Weight;
 use xcm::{
 	latest::{Asset, AssetId, Assets, Fungibility, Location, WeightLimit},
-	prelude::WeightLimit::*,
 	VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm, MAX_XCM_DECODE_DEPTH,
 };
 use xcm_executor::traits::TransferType;
@@ -99,14 +97,7 @@ where
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let assets: Vec<_> = assets.into();
 
-		let assets_to_send: Assets = assets
-			.into_iter()
-			.map(|asset| Asset {
-				id: AssetId(asset.0),
-				fun: Fungibility::Fungible(asset.1.converted()),
-			})
-			.collect::<Vec<Asset>>()
-			.into();
+		let (assets_to_send, _) = Self::get_assets_to_send_and_remote_fees(assets, None)?;
 
 		let call = pallet_xcm::Call::<Runtime>::transfer_assets {
 			dest: Box::new(VersionedLocation::V4(dest)),
@@ -145,7 +136,8 @@ where
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let assets: Vec<_> = assets.into();
 
-		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, _) = Self::get_assets_to_send_and_remote_fees(assets_converted, None)?;
 
 		let dest = XcmSiblingDestinationGenerator::generate(para_id);
 		let beneficiary = XcmLocalBeneficiary20Generator::generate(beneficiary.0 .0);
@@ -188,7 +180,8 @@ where
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let assets: Vec<_> = assets.into();
 
-		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, _) = Self::get_assets_to_send_and_remote_fees(assets_converted, None)?;
 
 		let dest = XcmSiblingDestinationGenerator::generate(para_id);
 		let beneficiary = XcmLocalBeneficiary32Generator::generate(beneficiary.0);
@@ -229,7 +222,8 @@ where
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let assets: Vec<_> = assets.into();
 
-		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, _) = Self::get_assets_to_send_and_remote_fees(assets_converted, None)?;
 
 		let dest = Location::parent();
 		let beneficiary = XcmLocalBeneficiary32Generator::generate(beneficiary.0);
@@ -247,26 +241,23 @@ where
 		Ok(())
 	}
 
+	// First selector type: no reserves at all
 	#[precompile::public(
 		"transferAssetsUsingTypeAndThenLocation(\
 		(uint8,bytes[]),\
 		((uint8,bytes[]),uint256)[],\
 		uint8,\
-		(uint8,bytes[]),\
 		uint8,\
 		uint8,\
-		(uint8,bytes[]),\
 		bytes)"
 	)]
-	fn transfer_assets_using_type_and_then_location(
+	fn transfer_assets_using_type_and_then_location_no_reserves(
 		handle: &mut impl PrecompileHandle,
 		dest: Location,
 		assets: BoundedVec<(Location, Convert<U256, u128>), GetArrayLimit>,
 		assets_transfer_type: u8,
-		maybe_assets_remote_reserve: Location,
 		remote_fees_id_index: u8,
 		fees_transfer_type: u8,
-		maybe_fees_remote_reserve: Location,
 		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
 	) -> EvmResult {
 		// No DB access before try_dispatch but some logical stuff.
@@ -277,26 +268,150 @@ where
 		let assets: Vec<_> = assets.into();
 		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
 
-		let remote_fees_id: AssetId = {
-			let asset = assets
-				.get(remote_fees_id_index as usize)
-				.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
-			AssetId(asset.0.clone())
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets.clone(),
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let assets_transfer_type = Self::check_transfer_type(assets_transfer_type, None)?;
+		let fees_transfer_type = Self::check_transfer_type(fees_transfer_type, None)?;
+
+		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
+			MAX_XCM_DECODE_DEPTH,
+			&mut custom_xcm_on_dest.as_slice(),
+		)
+		.map_err(|_| RevertReason::custom("Failed decoding custom XCM message"))?;
+
+		let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+			dest: Box::new(VersionedLocation::V4(dest)),
+			assets: Box::new(VersionedAssets::V4(assets_to_send)),
+			assets_transfer_type: Box::new(assets_transfer_type),
+			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
+			fees_transfer_type: Box::new(fees_transfer_type),
+			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
+			weight_limit: WeightLimit::Unlimited,
 		};
 
-		let assets_to_send: Assets = assets
-			.into_iter()
-			.map(|asset| Asset {
-				id: AssetId(asset.0),
-				fun: Fungibility::Fungible(asset.1.converted()),
-			})
-			.collect::<Vec<Asset>>()
-			.into();
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
 
+		Ok(())
+	}
+
+	// Either assets reserve or fees reserve
+	#[precompile::public(
+		"transferAssetsUsingTypeAndThenLocation(\
+		(uint8,bytes[]),\
+		((uint8,bytes[]),uint256)[],\
+		uint8,\
+		uint8,\
+		uint8,\
+		bytes,\
+		(uint8,bytes[]),\
+		bool)"
+	)]
+	fn transfer_assets_using_type_and_then_location_assets_or_fee_reserve(
+		handle: &mut impl PrecompileHandle,
+		dest: Location,
+		assets: BoundedVec<(Location, Convert<U256, u128>), GetArrayLimit>,
+		assets_transfer_type: u8,
+		remote_fees_id_index: u8,
+		fees_transfer_type: u8,
+		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
+		assets_or_fee_remote_reserve: Location,
+		is_assets_reserve: bool,
+	) -> EvmResult {
+		// No DB access before try_dispatch but some logical stuff.
+		// To prevent spam, we charge an arbitrary amount of gas.
+		handle.record_cost(1000)?;
+
+		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+		let assets: Vec<_> = assets.into();
+		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
+
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets.clone(),
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let (assets_transfer_type, fees_transfer_type) = if is_assets_reserve {
+			(
+				Self::check_transfer_type(
+					assets_transfer_type,
+					Some(assets_or_fee_remote_reserve),
+				)?,
+				Self::check_transfer_type(fees_transfer_type, None)?,
+			)
+		} else {
+			(
+				Self::check_transfer_type(assets_transfer_type, None)?,
+				Self::check_transfer_type(fees_transfer_type, Some(assets_or_fee_remote_reserve))?,
+			)
+		};
+
+		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
+			MAX_XCM_DECODE_DEPTH,
+			&mut custom_xcm_on_dest.as_slice(),
+		)
+		.map_err(|_| RevertReason::custom("Failed decoding custom XCM message"))?;
+
+		let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+			dest: Box::new(VersionedLocation::V4(dest)),
+			assets: Box::new(VersionedAssets::V4(assets_to_send)),
+			assets_transfer_type: Box::new(assets_transfer_type),
+			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
+			fees_transfer_type: Box::new(fees_transfer_type),
+			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
+			weight_limit: WeightLimit::Unlimited,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
+
+		Ok(())
+	}
+
+	// Both reserves for assets and fees
+	#[precompile::public(
+		"transferAssetsUsingTypeAndThenLocation(\
+		(uint8,bytes[]),\
+		((uint8,bytes[]),uint256)[],\
+		uint8,\
+		bytes,\
+		(uint8,bytes[]),\
+		(uint8,bytes[]))"
+	)]
+	fn transfer_assets_using_type_and_then_location_both_reserves(
+		handle: &mut impl PrecompileHandle,
+		dest: Location,
+		assets: BoundedVec<(Location, Convert<U256, u128>), GetArrayLimit>,
+		remote_fees_id_index: u8,
+		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
+		assets_remote_reserve: Location,
+		fees_remote_reserve: Location,
+	) -> EvmResult {
+		// No DB access before try_dispatch but some logical stuff.
+		// To prevent spam, we charge an arbitrary amount of gas.
+		handle.record_cost(1000)?;
+
+		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+		let assets: Vec<_> = assets.into();
+		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
+
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets.clone(),
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let remote_reserve_transfer_type: u8 = TransferTypeHelper::RemoteReserve as u8;
 		let assets_transfer_type =
-			Self::check_transfer_type(assets_transfer_type, maybe_assets_remote_reserve)?;
+			Self::check_transfer_type(remote_reserve_transfer_type, Some(assets_remote_reserve))?;
 		let fees_transfer_type =
-			Self::check_transfer_type(fees_transfer_type, maybe_fees_remote_reserve)?;
+			Self::check_transfer_type(remote_reserve_transfer_type, Some(fees_remote_reserve))?;
 
 		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
 			MAX_XCM_DECODE_DEPTH,
@@ -324,21 +439,17 @@ where
 		(uint8,bytes[]),\
 		(address,uint256)[],\
 		uint8,\
-		(uint8,bytes[]),\
 		uint8,\
 		uint8,\
-		(uint8,bytes[]),\
 		bytes)"
 	)]
-	fn transfer_assets_using_type_and_then_address(
+	fn transfer_assets_using_type_and_then_address_no_reserves(
 		handle: &mut impl PrecompileHandle,
 		dest: Location,
 		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
 		assets_transfer_type: u8,
-		maybe_assets_remote_reserve: Location,
 		remote_fees_id_index: u8,
 		fees_transfer_type: u8,
-		maybe_fees_remote_reserve: Location,
 		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
 	) -> EvmResult {
 		// Account for a possible storage read inside LocationMatcher::convert().
@@ -353,18 +464,159 @@ where
 		let assets: Vec<_> = assets.into();
 		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
 
-		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
-		let remote_fees_id: AssetId = {
-			let asset = assets_to_send
-				.get(remote_fees_id_index as usize)
-				.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
-			AssetId(asset.id.0.clone())
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets_converted,
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let assets_transfer_type = Self::check_transfer_type(assets_transfer_type, None)?;
+		let fees_transfer_type = Self::check_transfer_type(fees_transfer_type, None)?;
+
+		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
+			MAX_XCM_DECODE_DEPTH,
+			&mut custom_xcm_on_dest.as_slice(),
+		)
+		.map_err(|_| RevertReason::custom("Failed decoding custom XCM message"))?;
+
+		let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+			dest: Box::new(VersionedLocation::V4(dest)),
+			assets: Box::new(VersionedAssets::V4(assets_to_send.into())),
+			assets_transfer_type: Box::new(assets_transfer_type),
+			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
+			fees_transfer_type: Box::new(fees_transfer_type),
+			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
+			weight_limit: WeightLimit::Unlimited,
 		};
 
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
+
+		Ok(())
+	}
+
+	#[precompile::public(
+		"transferAssetsUsingTypeAndThenAddress(\
+		(uint8,bytes[]),\
+		(address,uint256)[],\
+		uint8,\
+		uint8,\
+		uint8,\
+		bytes,\
+		(uint8,bytes[]),\
+		bool)"
+	)]
+	fn transfer_assets_using_type_and_then_address_assets_or_fee_reserve(
+		handle: &mut impl PrecompileHandle,
+		dest: Location,
+		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
+		assets_transfer_type: u8,
+		remote_fees_id_index: u8,
+		fees_transfer_type: u8,
+		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
+		assets_or_fee_remote_reserve: Location,
+		is_assets_reserve: bool,
+	) -> EvmResult {
+		// Account for a possible storage read inside LocationMatcher::convert().
+		//
+		// Storage items: AssetIdToForeignAsset (ForeignAssetCreator pallet) or AssetIdType (AssetManager pallet).
+		//
+		// Blake2_128(16) + AssetId(16) + Location
+		handle.record_db_read::<Runtime>(32 + Location::max_encoded_len())?;
+		handle.record_cost(1000)?;
+
+		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+		let assets: Vec<_> = assets.into();
+		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
+
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets_converted,
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let (assets_transfer_type, fees_transfer_type) = if is_assets_reserve {
+			(
+				Self::check_transfer_type(
+					assets_transfer_type,
+					Some(assets_or_fee_remote_reserve),
+				)?,
+				Self::check_transfer_type(fees_transfer_type, None)?,
+			)
+		} else {
+			(
+				Self::check_transfer_type(assets_transfer_type, None)?,
+				Self::check_transfer_type(fees_transfer_type, Some(assets_or_fee_remote_reserve))?,
+			)
+		};
+
+		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
+			MAX_XCM_DECODE_DEPTH,
+			&mut custom_xcm_on_dest.as_slice(),
+		)
+		.map_err(|_| RevertReason::custom("Failed decoding custom XCM message"))?;
+
+		let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+			dest: Box::new(VersionedLocation::V4(dest)),
+			assets: Box::new(VersionedAssets::V4(assets_to_send.into())),
+			assets_transfer_type: Box::new(assets_transfer_type),
+			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
+			fees_transfer_type: Box::new(fees_transfer_type),
+			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
+			weight_limit: WeightLimit::Unlimited,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
+
+		Ok(())
+	}
+
+	#[precompile::public(
+		"transferAssetsUsingTypeAndThenAddress(\
+		(uint8,bytes[]),\
+		(address,uint256)[],\
+		uint8,\
+		bytes,\
+		(uint8,bytes[]),\
+		(uint8,bytes[]))"
+	)]
+	fn transfer_assets_using_type_and_then_address_both_reserves(
+		handle: &mut impl PrecompileHandle,
+		dest: Location,
+		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
+		remote_fees_id_index: u8,
+		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
+		assets_remote_reserve: Location,
+		fees_remote_reserve: Location,
+	) -> EvmResult {
+		// Account for a possible storage read inside LocationMatcher::convert().
+		//
+		// Storage items: AssetIdToForeignAsset (ForeignAssetCreator pallet) or AssetIdType (AssetManager pallet).
+		//
+		// Blake2_128(16) + AssetId(16) + Location
+		handle.record_db_read::<Runtime>(32 + Location::max_encoded_len())?;
+		handle.record_cost(1000)?;
+
+		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+		let assets: Vec<_> = assets.into();
+		let custom_xcm_on_dest: Vec<u8> = custom_xcm_on_dest.into();
+
+		let assets_converted = Self::convert_assets(assets)?;
+		let (assets_to_send, remote_fees_id) = Self::get_assets_to_send_and_remote_fees(
+			assets_converted,
+			Some(remote_fees_id_index as usize),
+		)?;
+		let remote_fees_id =
+			remote_fees_id.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+
+		let remote_reserve_transfer_type: u8 = TransferTypeHelper::RemoteReserve as u8;
 		let assets_transfer_type =
-			Self::check_transfer_type(assets_transfer_type, maybe_assets_remote_reserve)?;
+			Self::check_transfer_type(remote_reserve_transfer_type, Some(assets_remote_reserve))?;
 		let fees_transfer_type =
-			Self::check_transfer_type(fees_transfer_type, maybe_fees_remote_reserve)?;
+			Self::check_transfer_type(remote_reserve_transfer_type, Some(fees_remote_reserve))?;
 
 		let custom_xcm_on_dest = VersionedXcm::<()>::decode_all_with_depth_limit(
 			MAX_XCM_DECODE_DEPTH,
@@ -388,19 +640,16 @@ where
 	}
 
 	// Helper function to convert and prepare each asset into a proper Location.
-	fn check_and_prepare_assets(
+	fn convert_assets(
 		assets: Vec<(Address, Convert<U256, u128>)>,
-	) -> Result<Vec<Asset>, PrecompileFailure> {
-		let mut assets_to_send: Vec<Asset> = vec![];
+	) -> Result<Vec<(Location, Convert<U256, u128>)>, PrecompileFailure> {
+		let mut assets_to_send: Vec<(Location, Convert<U256, u128>)> = vec![];
 		for asset in assets {
 			let asset_account = Runtime::AddressMapping::into_account_id(asset.0 .0);
 			let asset_location = LocationMatcher::convert(asset_account);
 
 			if let Some(asset_loc) = asset_location {
-				assets_to_send.push(Asset {
-					id: AssetId(asset_loc),
-					fun: Fungibility::Fungible(asset.1.converted()),
-				})
+				assets_to_send.push((asset_loc, asset.1))
 			} else {
 				return Err(revert("Asset not found"));
 			}
@@ -410,7 +659,7 @@ where
 
 	fn check_transfer_type(
 		transfer_type: u8,
-		remote_reserve: Location,
+		maybe_remote_reserve: Option<Location>,
 	) -> Result<TransferType, PrecompileFailure> {
 		let transfer_type_helper: TransferTypeHelper = TransferTypeHelper::decode(
 			&mut transfer_type.to_le_bytes().as_slice(),
@@ -422,10 +671,40 @@ where
 			TransferTypeHelper::LocalReserve => return Ok(TransferType::LocalReserve),
 			TransferTypeHelper::DestinationReserve => return Ok(TransferType::DestinationReserve),
 			TransferTypeHelper::RemoteReserve => {
-				return Ok(TransferType::RemoteReserve(VersionedLocation::V4(
-					remote_reserve,
-				)))
+				if let Some(remote_reserve) = maybe_remote_reserve {
+					return Ok(TransferType::RemoteReserve(VersionedLocation::V4(
+						remote_reserve,
+					)));
+				} else {
+					return Err(RevertReason::custom("No reserve specified!").into());
+				}
 			}
 		}
+	}
+
+	fn get_assets_to_send_and_remote_fees(
+		assets: Vec<(Location, Convert<U256, u128>)>,
+		remote_fees_id_index: Option<usize>,
+	) -> Result<(Assets, Option<AssetId>), PrecompileFailure> {
+		let assets_to_send: Assets = assets
+			.into_iter()
+			.map(|asset| Asset {
+				id: AssetId(asset.0),
+				fun: Fungibility::Fungible(asset.1.converted()),
+			})
+			.collect::<Vec<Asset>>()
+			.into();
+
+		if let Some(index) = remote_fees_id_index {
+			let remote_fees_id: AssetId = {
+				let asset = assets_to_send
+					.get(index)
+					.ok_or_else(|| RevertReason::custom("remote_fees_id not found"))?;
+				AssetId(asset.id.0.clone())
+			};
+			return Ok((assets_to_send, Some(remote_fees_id)));
+		}
+
+		Ok((assets_to_send, None))
 	}
 }

--- a/precompiles/pallet-xcm/src/lib.rs
+++ b/precompiles/pallet-xcm/src/lib.rs
@@ -31,7 +31,7 @@ use sp_runtime::traits::Dispatchable;
 use sp_std::{boxed::Box, marker::PhantomData, vec, vec::Vec};
 use sp_weights::Weight;
 use xcm::{
-	latest::{Asset, AssetId, Assets, Fungibility, Location},
+	latest::{Asset, AssetId, Assets, Fungibility, Location, WeightLimit},
 	prelude::WeightLimit::*,
 	VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm, MAX_XCM_DECODE_DEPTH,
 };
@@ -83,8 +83,7 @@ where
 		(uint8,bytes[]),\
 		(uint8,bytes[]),\
 		((uint8,bytes[]),uint256)[],\
-		uint32,\
-		(uint64,uint64))"
+		uint32)"
 	)]
 	fn transfer_assets_location(
 		handle: &mut impl PrecompileHandle,
@@ -92,7 +91,6 @@ where
 		beneficiary: Location,
 		assets: BoundedVec<(Location, Convert<U256, u128>), GetArrayLimit>,
 		fee_asset_item: u32,
-		weight: Weight,
 	) -> EvmResult {
 		// No DB access before try_dispatch but some logical stuff.
 		// To prevent spam, we charge an arbitrary amount of gas.
@@ -110,17 +108,12 @@ where
 			.collect::<Vec<Asset>>()
 			.into();
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let call = pallet_xcm::Call::<Runtime>::transfer_assets {
 			dest: Box::new(VersionedLocation::V4(dest)),
 			beneficiary: Box::new(VersionedLocation::V4(beneficiary)),
 			assets: Box::new(VersionedAssets::V4(assets_to_send)),
 			fee_asset_item,
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
@@ -132,8 +125,7 @@ where
 			uint32,\
 			address,\
 			(address,uint256)[],\
-			uint32,\
-			(uint64,uint64))"
+			uint32)"
 	)]
 	fn transfer_assets_to_para_20(
 		handle: &mut impl PrecompileHandle,
@@ -141,7 +133,6 @@ where
 		beneficiary: Address,
 		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
 		fee_asset_item: u32,
-		weight: Weight,
 	) -> EvmResult {
 		// Account for a possible storage read inside LocationMatcher::convert().
 		//
@@ -156,11 +147,6 @@ where
 
 		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let dest = XcmSiblingDestinationGenerator::generate(para_id);
 		let beneficiary = XcmLocalBeneficiary20Generator::generate(beneficiary.0 .0);
 
@@ -169,7 +155,7 @@ where
 			beneficiary: Box::new(VersionedLocation::V4(beneficiary)),
 			assets: Box::new(VersionedAssets::V4(assets_to_send.into())),
 			fee_asset_item,
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
@@ -182,8 +168,7 @@ where
 			uint32,\
 			bytes32,\
 			(address,uint256)[],\
-			uint32,\
-			(uint64,uint64))"
+			uint32)"
 	)]
 	fn transfer_assets_to_para_32(
 		handle: &mut impl PrecompileHandle,
@@ -191,7 +176,6 @@ where
 		beneficiary: H256,
 		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
 		fee_asset_item: u32,
-		weight: Weight,
 	) -> EvmResult {
 		// Account for a possible storage read inside LocationMatcher::convert().
 		//
@@ -206,11 +190,6 @@ where
 
 		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let dest = XcmSiblingDestinationGenerator::generate(para_id);
 		let beneficiary = XcmLocalBeneficiary32Generator::generate(beneficiary.0);
 
@@ -219,7 +198,7 @@ where
 			beneficiary: Box::new(VersionedLocation::V4(beneficiary)),
 			assets: Box::new(VersionedAssets::V4(assets_to_send.into())),
 			fee_asset_item,
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
@@ -231,15 +210,13 @@ where
 		"transferAssetsToRelay(\
 			bytes32,\
 			(address,uint256)[],\
-			uint32,\
-			(uint64,uint64))"
+			uint32)"
 	)]
 	fn transfer_assets_to_relay(
 		handle: &mut impl PrecompileHandle,
 		beneficiary: H256,
 		assets: BoundedVec<(Address, Convert<U256, u128>), GetArrayLimit>,
 		fee_asset_item: u32,
-		weight: Weight,
 	) -> EvmResult {
 		// Account for a possible storage read inside LocationMatcher::convert().
 		//
@@ -254,11 +231,6 @@ where
 
 		let assets_to_send: Vec<Asset> = Self::check_and_prepare_assets(assets)?;
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let dest = Location::parent();
 		let beneficiary = XcmLocalBeneficiary32Generator::generate(beneficiary.0);
 
@@ -267,7 +239,7 @@ where
 			beneficiary: Box::new(VersionedLocation::V4(beneficiary)),
 			assets: Box::new(VersionedAssets::V4(assets_to_send.into())),
 			fee_asset_item,
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
@@ -284,8 +256,7 @@ where
 		uint8,\
 		uint8,\
 		(uint8,bytes[]),\
-		bytes,\
-		(uint64,uint64))"
+		bytes)"
 	)]
 	fn transfer_assets_using_type_and_then_location(
 		handle: &mut impl PrecompileHandle,
@@ -297,7 +268,6 @@ where
 		fees_transfer_type: u8,
 		maybe_fees_remote_reserve: Location,
 		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
-		weight: Weight,
 	) -> EvmResult {
 		// No DB access before try_dispatch but some logical stuff.
 		// To prevent spam, we charge an arbitrary amount of gas.
@@ -323,11 +293,6 @@ where
 			.collect::<Vec<Asset>>()
 			.into();
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let assets_transfer_type =
 			Self::check_transfer_type(assets_transfer_type, maybe_assets_remote_reserve)?;
 		let fees_transfer_type =
@@ -346,7 +311,7 @@ where
 			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
 			fees_transfer_type: Box::new(fees_transfer_type),
 			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
@@ -363,8 +328,7 @@ where
 		uint8,\
 		uint8,\
 		(uint8,bytes[]),\
-		bytes,\
-		(uint64,uint64))"
+		bytes)"
 	)]
 	fn transfer_assets_using_type_and_then_address(
 		handle: &mut impl PrecompileHandle,
@@ -376,7 +340,6 @@ where
 		fees_transfer_type: u8,
 		maybe_fees_remote_reserve: Location,
 		custom_xcm_on_dest: BoundedBytes<GetXcmSizeLimit>,
-		weight: Weight,
 	) -> EvmResult {
 		// Account for a possible storage read inside LocationMatcher::convert().
 		//
@@ -398,11 +361,6 @@ where
 			AssetId(asset.id.0.clone())
 		};
 
-		let weight_limit = match weight.ref_time() {
-			u64::MAX => Unlimited,
-			_ => Limited(weight),
-		};
-
 		let assets_transfer_type =
 			Self::check_transfer_type(assets_transfer_type, maybe_assets_remote_reserve)?;
 		let fees_transfer_type =
@@ -421,7 +379,7 @@ where
 			remote_fees_id: Box::new(VersionedAssetId::V4(remote_fees_id)),
 			fees_transfer_type: Box::new(fees_transfer_type),
 			custom_xcm_on_dest: Box::new(custom_xcm_on_dest),
-			weight_limit,
+			weight_limit: WeightLimit::Unlimited,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -556,6 +556,7 @@ fn test_transfer_assets_using_type_and_then_address_remote_reserve() {
 			let asset_address =
 				H160::from_str("0xfFfFFFffFffFFFFffFFfFfffFfFFFFFfffFF0005").unwrap();
 
+			let dest = Location::new(1, [Parachain(2)]);
 			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
@@ -563,7 +564,7 @@ fn test_transfer_assets_using_type_and_then_address_remote_reserve() {
 					Alice,
 					Precompile1,
 					PCall::transfer_assets_using_type_and_then_address_remote_reserve {
-						dest: Location::parent(),
+						dest,
 						assets: vec![(Address(asset_address), 500.into())].into(),
 						remote_fees_id_index: 0u8,
 						custom_xcm_on_dest: message.into(),

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -19,7 +19,6 @@ use core::str::FromStr;
 use crate::{mock::*, Location};
 use precompile_utils::{prelude::*, testing::*};
 use sp_core::{H160, H256};
-use sp_weights::Weight;
 use xcm::latest::Junction::*;
 
 fn precompiles() -> Precompiles<Runtime, (SingleAddressMatch, ForeignAssetMatch)> {

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -505,7 +505,7 @@ fn test_transfer_assets_using_type_and_then_address_no_remote_reserve() {
 					Precompile1,
 					PCall::transfer_assets_using_type_and_then_address_no_remote_reserve {
 						dest: Location::parent(),
-						assets:  vec![
+						assets: vec![
 							(Address(pallet_balances_address), 500.into()),
 							(Address(asset_address), 500.into()),
 						]
@@ -548,13 +548,10 @@ fn test_transfer_assets_using_type_and_then_address_remote_reserve() {
 					Precompile1,
 					PCall::transfer_assets_using_type_and_then_address_remote_reserve {
 						dest: Location::parent(),
-						assets:  vec![
-							(Address(asset_address), 500.into()),
-						]
-						.into(),
+						assets: vec![(Address(asset_address), 500.into())].into(),
 						remote_fees_id_index: 0u8,
 						custom_xcm_on_dest: message.into(),
-						remote_reserve: Location::parent()
+						remote_reserve: Location::parent(),
 					},
 				)
 				.expect_cost(100001002)

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -33,10 +33,10 @@ fn test_solidity_interface_has_all_function_selectors_documented_and_implemented
 
 #[test]
 fn selectors() {
-	assert!(PCall::transfer_assets_location_selectors().contains(&0x59df8416));
-	assert!(PCall::transfer_assets_to_para_20_selectors().contains(&0xb489262e));
-	assert!(PCall::transfer_assets_to_para_32_selectors().contains(&0x4461e6f5));
-	assert!(PCall::transfer_assets_to_relay_selectors().contains(&0xd7c89659));
+	assert!(PCall::transfer_assets_location_selectors().contains(&0x9ea8ada7));
+	assert!(PCall::transfer_assets_to_para_20_selectors().contains(&0xa0aeb5fe));
+	assert!(PCall::transfer_assets_to_para_32_selectors().contains(&0xf23032c3));
+	assert!(PCall::transfer_assets_to_relay_selectors().contains(&0x6521cc2c));
 }
 
 #[test]
@@ -101,9 +101,6 @@ fn test_transfer_assets_works() {
 						]
 						.into(),
 						fee_asset_item: 0u32,
-						// As we are indicating u64::MAX in ref_time, an Unlimited variant
-						// will be applied at the end.
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001001)
@@ -147,9 +144,6 @@ fn test_transfer_assets_success_when_paying_fees_with_foreign_asset() {
 						// We also act as a reserve for the foreign asset thus when can pay local
 						// fees with it.
 						fee_asset_item: 1u32,
-						// As we are indicating u64::MAX in ref_time, an Unlimited variant
-						// will be applied at the end.
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001001)
@@ -192,9 +186,6 @@ fn test_transfer_assets_fails_fees_unknown_reserve() {
 						.into(),
 						// No reserve will be found for this asset.
 						fee_asset_item: 1u32,
-						// As we are indicating u64::MAX in ref_time, an Unlimited variant
-						// will be applied at the end.
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_no_logs()
@@ -220,7 +211,6 @@ fn test_transfer_assets_to_para_20_native_asset() {
 						beneficiary: Address(Bob.into()),
 						assets: vec![(Address(pallet_balances_address), 500.into())].into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)
@@ -247,7 +237,6 @@ fn test_transfer_assets_to_para_32_native_asset() {
 						beneficiary: H256([1u8; 32]),
 						assets: vec![(Address(pallet_balances_address), 500.into())].into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)
@@ -273,7 +262,6 @@ fn test_transfer_assets_to_relay_native_asset() {
 						beneficiary: H256([1u8; 32]),
 						assets: vec![(Address(pallet_balances_address), 500.into())].into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)
@@ -316,7 +304,6 @@ fn test_transfer_assets_to_para_20_foreign_asset() {
 						]
 						.into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)
@@ -359,7 +346,6 @@ fn test_transfer_assets_to_para_32_foreign_asset() {
 						]
 						.into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)
@@ -401,7 +387,6 @@ fn test_transfer_assets_to_relay_foreign_asset() {
 						]
 						.into(),
 						fee_asset_item: 0u32,
-						weight: Weight::from_parts(u64::MAX, 80000),
 					},
 				)
 				.expect_cost(100001002)

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -38,10 +38,22 @@ fn selectors() {
 	assert!(PCall::transfer_assets_to_para_20_selectors().contains(&0xa0aeb5fe));
 	assert!(PCall::transfer_assets_to_para_32_selectors().contains(&0xf23032c3));
 	assert!(PCall::transfer_assets_to_relay_selectors().contains(&0x6521cc2c));
-	assert!(PCall::transfer_assets_using_type_and_then_location_no_remote_reserve_selectors().contains(&0x8425d893));
-	assert!(PCall::transfer_assets_using_type_and_then_location_remote_reserve_selectors().contains(&0xfc19376c));
-	assert!(PCall::transfer_assets_using_type_and_then_address_no_remote_reserve_selectors().contains(&0x998093ee));
-	assert!(PCall::transfer_assets_using_type_and_then_address_remote_reserve_selectors().contains(&0xaaecfc62));
+	assert!(
+		PCall::transfer_assets_using_type_and_then_location_no_remote_reserve_selectors()
+			.contains(&0x8425d893)
+	);
+	assert!(
+		PCall::transfer_assets_using_type_and_then_location_remote_reserve_selectors()
+			.contains(&0xfc19376c)
+	);
+	assert!(
+		PCall::transfer_assets_using_type_and_then_address_no_remote_reserve_selectors()
+			.contains(&0x998093ee)
+	);
+	assert!(
+		PCall::transfer_assets_using_type_and_then_address_remote_reserve_selectors()
+			.contains(&0xaaecfc62)
+	);
 }
 
 #[test]

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -38,6 +38,10 @@ fn selectors() {
 	assert!(PCall::transfer_assets_to_para_20_selectors().contains(&0xa0aeb5fe));
 	assert!(PCall::transfer_assets_to_para_32_selectors().contains(&0xf23032c3));
 	assert!(PCall::transfer_assets_to_relay_selectors().contains(&0x6521cc2c));
+	assert!(PCall::transfer_assets_using_type_and_then_location_no_remote_reserve_selectors().contains(&0x8425d893));
+	assert!(PCall::transfer_assets_using_type_and_then_location_remote_reserve_selectors().contains(&0xfc19376c));
+	assert!(PCall::transfer_assets_using_type_and_then_address_no_remote_reserve_selectors().contains(&0x998093ee));
+	assert!(PCall::transfer_assets_using_type_and_then_address_remote_reserve_selectors().contains(&0xaaecfc62));
 }
 
 #[test]


### PR DESCRIPTION
### What does it do?

This PR adds support for `transfer_assets_using_type_and_then` extrinsic in pallet-xcm precompile. 

In total 4 new selectors were added to the pallet-xcm precompile interface:

- Selector `8425d893`: 

This function allows calling `transfer_assets_using_type_and_then` extrinsic (with assets being represented in `Location` format) by ONLY allowing combinations of `LocalReserve`, `Teleport`, and `DestinationReserve` transfer types. `RemoteReserve` type is not allowed here. It was decided to split the behavior in two functions for better params organization.

```solidity
    /// @custom:selector 8425d893
    function transferAssetsUsingTypeAndThenLocation(
        Location memory dest,
        AssetLocationInfo[] memory assets,
        TransferType assetsTransferType,
        uint8 remoteFeesIdIndex,
        TransferType feesTransferType,
        bytes memory customXcmOnDest
    ) external;
```

- Selector `fc19376c`:

This function allows calling `transfer_assets_using_type_and_then` extrinsic (with assets being represented in `Location` format) through the `RemoteReserve` transfer type for both assets and fees. In this case, assets and fees MUST share the same reserve for the extrinsic to execute properly. This is being restricted by pallet-xcm, as it doesn't allow to send XCMs to separate chains, given that there is no guarantee of delivery order on final destination (more details [here](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/pallet-xcm/src/lib.rs#L1663-L1667)).

```solidity
    /// @custom:selector fc19376c
    function transferAssetsUsingTypeAndThenLocation(
        Location memory dest,
        AssetLocationInfo[] memory assets,
        uint8 remoteFeesIdIndex,
        bytes memory customXcmOnDest,
        Location memory remoteReserve
    ) external;
```

- The other 2 remaining selectors (`998093ee` and `aaecfc62`) are identical to the ones described above. The only difference is that they receive the assets in `Address` format.

```solidity
    /// @custom:selector 998093ee
    function transferAssetsUsingTypeAndThenAddress(
        Location memory dest,
        AssetAddressInfo[] memory assets,
        TransferType assetsTransferType,
        uint8 remoteFeesIdIndex,
        TransferType feesTransferType,
        bytes memory customXcmOnDest
    ) external;

    /// @custom:selector aaecfc62
    function transferAssetsUsingTypeAndThenAddress(
        Location memory dest,
        AssetAddressInfo[] memory assets,
        uint8 remoteFeesIdIndex,
        bytes memory customXcmOnDest,
        Location memory remoteReserve
    ) external;
```

### Related upstream PRs

- https://github.com/paritytech/polkadot-sdk/pull/3695
- https://github.com/paritytech/polkadot-sdk/pull/4260