### PR TITLE
explicitly set fork_chain when sealing a block

### DIFF
--- a/client/consensus/nimbus-consensus/src/collators.rs
+++ b/client/consensus/nimbus-consensus/src/collators.rs
@@ -118,6 +118,8 @@ where
 	block_import_params.state_action = sc_consensus::StateAction::ApplyChanges(
 		sc_consensus::StorageChanges::Changes(storage_changes),
 	);
+	// The collator should follow the longest chain
+	block_import_params.fork_choice = Some(sc_consensus::ForkChoiceStrategy::LongestChain);
 
 	let post_hash = block_import_params.post_hash();
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -156,7 +156,7 @@ pub fn new_partial(
 		},
 		&task_manager.spawn_essential_handle(),
 		config.prometheus_registry().clone(),
-		None,
+		false,
 	)?;
 
 	Ok(PartialComponents {


### PR DESCRIPTION
This pull request fixes an issue when importing a block, the collators now need to explicitly provide the `fork_choice` when sealing a block.