### PR TITLE
Add internal function `force_enter_maintenance_mode`

### DIFF
--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -181,6 +181,24 @@ pub mod pallet {
 		}
 	}
 
+	impl<T: Config> Pallet<T> {
+		/// Internal function to force the chain into maintenance mode without an origin check.
+		pub fn force_enter_maintenance_mode() {
+			// Write to storage
+			MaintenanceMode::<T>::put(true);
+
+			// Suspend XCM execution
+			#[cfg(feature = "xcm-support")]
+			if let Err(error) = T::XcmExecutionManager::suspend_xcm_execution() {
+				// Deposit event about failure but still return the error to the caller
+				<Pallet<T>>::deposit_event(Event::FailedToSuspendIdleXcmExecution { error });
+			}
+
+			// Event
+			<Pallet<T>>::deposit_event(Event::EnteredMaintenanceMode);
+		}
+	}
+
 	#[derive(frame_support::DefaultNoBound)]
 	#[pallet::genesis_config]
 	/// Genesis config for maintenance mode pallet


### PR DESCRIPTION
# Description

The primary motivation for this addition is to enable the runtime to programmatically activate maintenance mode without an explicit origin check. This adds the capability of implementing automated safety mechanisms, such as the one employed on Moonbeam to enter maintenance mode on a migration failure.

```rust
pub struct EnterMaintenanceModeOnFailedMigration;
impl frame_support::migrations::FailedMigrationHandler for EnterMaintenanceModeOnFailedMigration {
	fn failed(migration: Option<u32>) -> frame_support::migrations::FailedMigrationHandling {
		// Log information about the failed migration
		log::error!(
			target: "runtime::migrations",
			"Migration {:?} failed - activating maintenance mode and continuing",
			migration
		);

		// Enable maintenance mode using the internal function.
		MaintenanceMode::force_enter_maintenance_mode();

		// We choose to ignore the failed migration, allowing the chain to continue operating
		// in maintenance mode rather than completely halting execution
		frame_support::migrations::FailedMigrationHandling::Ignore
	}
}
```