### PR TITLE
Upgrade the version of `polkadot-sdk` to `stable2503`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -196,7 +196,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -205,9 +205,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -216,10 +216,22 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -228,10 +240,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -240,15 +252,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381-bandersnatch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1786b2e3832f6f0f7c8d62d5d5a282f6952a1ab99981c54cd52b6ac1d8f02df5"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -260,6 +305,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +332,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -283,16 +358,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -301,8 +404,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -319,13 +435,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-transcript"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c1c928edb9d8ff24cb5dcb7651d3a98494fff3099eee95c2404cd813a9139f"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+ "sha3",
+]
+
+[[package]]
+name = "ark-vrf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9501da18569b2afe0eb934fb7afd5a247d238b94116155af4dd068f319adfe6d"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "digest 0.10.7",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.9",
+ "w3f-ring-proof",
+ "zeroize",
 ]
 
 [[package]]
@@ -357,12 +527,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
@@ -373,30 +543,18 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -407,19 +565,20 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
+name = "asn1-rs-derive"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -430,7 +589,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -472,14 +631,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
  "futures-lite 2.6.0",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -649,13 +809,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -663,6 +823,19 @@ name = "asynchronous-codec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -696,13 +869,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -713,9 +886,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line 0.24.2",
  "cfg-if",
@@ -764,23 +937,14 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "hash-db",
  "log",
@@ -814,7 +978,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -826,10 +990,10 @@ dependencies = [
  "bs58",
  "hmac 0.12.1",
  "k256",
- "rand_core",
+ "rand_core 0.6.4",
  "ripemd",
  "secp256k1 0.27.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -840,7 +1004,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.13.0",
  "serde",
  "unicode-normalization",
 ]
@@ -852,13 +1016,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
  "bitcoin-internals",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -869,9 +1049,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -941,16 +1121,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.1",
- "memmap2 0.9.5",
 ]
 
 [[package]]
@@ -986,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ed0a820ed50891d36358e997d27741a6142e382242df40ff01c89bcdcc7a2b"
+checksum = "64ad8a0bed7827f0b07a5d23cec2e58cc02038a99e4ca81616cb2bb2025f804d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1007,8 +1186,8 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1023,15 +1202,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -1055,9 +1234,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-tools"
@@ -1067,9 +1246,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -1079,18 +1258,17 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -1130,7 +1308,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1144,9 +1322,9 @@ checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -1231,16 +1409,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1258,15 +1436,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.3",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -1302,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1312,27 +1489,27 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1343,9 +1520,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4252bf230cb600c19826a575b31c8c9c84c6f11acfab6dfcad2e941b10b6f8e2"
+checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
 dependencies = [
  "libc",
  "wasix",
@@ -1354,12 +1531,13 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1385,7 +1563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1405,22 +1583,22 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "const-hex"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1450,7 +1628,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1486,12 +1664,6 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "convert_case"
@@ -1716,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1728,7 +1900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1753,6 +1925,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher 0.4.4",
+ "generic-array 0.14.7",
+ "poly1305",
+ "salsa20",
+ "subtle 2.6.1",
+ "zeroize",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,8 +1950,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1780,8 +1967,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1803,8 +1990,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1833,8 +2020,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1848,8 +2035,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1874,8 +2061,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1884,20 +2071,18 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
- "sp-trie",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1909,7 +2094,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
  "sp-api",
@@ -1922,8 +2107,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.23.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1959,8 +2144,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.20.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1976,7 +2161,6 @@ dependencies = [
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
@@ -1996,18 +2180,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2021,8 +2205,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.20.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2046,8 +2230,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.18.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2062,8 +2246,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.18.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2076,8 +2260,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.12.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2085,9 +2269,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-primitives-storage-weight-reclaim"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+dependencies = [
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "cumulus-primitives-timestamp"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2096,8 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.20.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2113,8 +2314,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.23.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2137,13 +2338,13 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "futures 0.3.31",
- "jsonrpsee-core 0.24.8",
+ "jsonrpsee-core",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
@@ -2156,8 +2357,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.23.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2185,14 +2386,13 @@ dependencies = [
  "sp-consensus-babe",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.22.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2200,12 +2400,12 @@ dependencies = [
  "either",
  "futures 0.3.31",
  "futures-timer",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "parity-scale-codec",
  "pin-project",
  "polkadot-overseer",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -2214,7 +2414,6 @@ dependencies = [
  "serde_json",
  "smoldot 0.11.0",
  "smoldot-light 0.9.0",
- "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
@@ -2232,8 +2431,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2267,7 +2466,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2278,16 +2477,16 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.140"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc49567e08c72902f4cbc7242ee8d874ec9cbe97fbabf77b4e0e1f447513e13a"
+checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -2299,117 +2498,82 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.140"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe46b5309c99e9775e7a338c98e4097455f52db5b684fd793ca22848fde6e371"
+checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.140"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4315c4ce8d23c26d87f2f83698725fd5718d8e6ace4a9093da2664d23294d372"
+checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.140"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55d69deb3a92f610a60ecc524a72c7374b6dc822f8fb7bb4e5d9473f10530c4"
+checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.140"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bee7a1d9b5091462002c2b8de2a4ed0f0fde011d503cc272633f66075bd5141"
+checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.98",
+ "strsim",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.14.4",
+ "darling_core",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core 0.20.10",
- "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2427,15 +2591,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2443,36 +2607,22 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
-dependencies = [
- "asn1-rs 0.5.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -2490,10 +2640,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
+name = "der-parser"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -2517,31 +2681,31 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2561,7 +2725,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -2570,12 +2734,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2627,6 +2785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,14 +2824,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "docify"
@@ -2687,9 +2854,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.101",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
 ]
 
@@ -2707,9 +2874,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dyn-clonable"
@@ -2729,14 +2896,14 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -2771,9 +2938,9 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -2788,16 +2955,28 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
- "sha2 0.10.8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
 [[package]]
-name = "either"
-version = "1.13.0"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -2812,7 +2991,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -2827,18 +3006,6 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
@@ -2846,7 +3013,27 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2866,7 +3053,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2877,7 +3064,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2907,12 +3094,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2923,9 +3110,9 @@ checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.5.0",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
 ]
@@ -2933,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.15.0"
-source = "git+https://github.com/rust-ethereum/ethereum.git?rev=3be0d8fd4c2ad1ba216b69ef65b9382612efc8ba#3be0d8fd4c2ad1ba216b69ef65b9382612efc8ba"
+source = "git+https://github.com/rust-ethereum/ethereum?rev=bbb544622208ef6e9890a2dbc224248f6dd13318#bbb544622208ef6e9890a2dbc224248f6dd13318"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2955,10 +3142,10 @@ checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.5.0",
- "primitive-types 0.13.1",
+ "impl-serde",
+ "primitive-types",
  "scale-info",
  "uint 0.10.0",
 ]
@@ -2982,16 +3169,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -3003,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -3014,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6d86fe2d3bcc14887c2575f62958a67ac2d523db"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -3024,7 +3201,7 @@ dependencies = [
  "evm-runtime",
  "log",
  "parity-scale-codec",
- "primitive-types 0.13.1",
+ "primitive-types",
  "rlp",
  "scale-info",
  "serde",
@@ -3034,10 +3211,10 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6d86fe2d3bcc14887c2575f62958a67ac2d523db"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
 dependencies = [
  "parity-scale-codec",
- "primitive-types 0.13.1",
+ "primitive-types",
  "scale-info",
  "serde",
 ]
@@ -3045,23 +3222,23 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6d86fe2d3bcc14887c2575f62958a67ac2d523db"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
 dependencies = [
  "environmental",
  "evm-core",
  "evm-runtime",
- "primitive-types 0.13.1",
+ "primitive-types",
 ]
 
 [[package]]
 name = "evm-runtime"
 version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6d86fe2d3bcc14887c2575f62958a67ac2d523db"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
 dependencies = [
  "auto_impl",
  "environmental",
  "evm-core",
- "primitive-types 0.13.1",
+ "primitive-types",
  "sha3",
 ]
 
@@ -3086,7 +3263,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3139,11 +3316,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.7.1",
- "proc-macro-crate 3.2.0",
+ "indexmap 2.9.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3158,11 +3335,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3221,23 +3398,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "finito"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2384245d85162258a14b43567a9ee3598f5ae746a1581fb5d3d2cb780f0dbf95"
-dependencies = [
- "futures-timer",
- "pin-project",
-]
-
-[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3253,15 +3420,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "flume"
@@ -3283,14 +3441,14 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3317,10 +3475,10 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#4dddde8766dc23337ade83fbd5836dd9e4d7326d"
+source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
 dependencies = [
  "hex",
- "impl-serde 0.5.0",
+ "impl-serde",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -3336,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#4dddde8766dc23337ade83fbd5836dd9e4d7326d"
+source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
 dependencies = [
  "environmental",
  "evm",
@@ -3351,14 +3509,14 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3381,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "47.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3396,14 +3554,13 @@ dependencies = [
  "frame-system",
  "gethostname",
  "handlebars",
- "hex",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
  "sc-chain-spec",
@@ -3411,7 +3568,7 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-executor",
- "sc-executor-common",
+ "sc-runtime-utilities",
  "sc-service",
  "sc-sysinfo",
  "serde",
@@ -3420,7 +3577,6 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-database",
  "sp-externalities",
  "sp-genesis-builder",
@@ -3442,20 +3598,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-election-provider-solution-type"
-version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+name = "frame-decode"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6027a409bac4fe95b4d107f965fcdbc252fc89d884a360d076b3070b6128c094"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "frame-metadata 17.0.0",
+ "parity-scale-codec",
+ "scale-decode 0.14.0",
+ "scale-info",
+ "scale-type-resolver",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "frame-election-provider-solution-type"
+version = "16.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+dependencies = [
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3470,8 +3640,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3488,20 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "15.1.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878babb0b136e731cc77ec2fd883ff02745ff21e6fb662729953d44923df009c"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf1549fba25a6fcac22785b61698317d958e96cac72a59102ea45b9ae64692"
+checksum = "701bac17e9b55e0f95067c428ebcb46496587f08e8cf4ccc0fe5903bea10dbb8"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -3511,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "18.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
+checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -3523,8 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata-hash-extension"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3539,8 +3698,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3548,7 +3707,7 @@ dependencies = [
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
@@ -3559,7 +3718,6 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-core",
@@ -3576,14 +3734,13 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-weights",
- "static_assertions",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "33.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3593,43 +3750,43 @@ dependencies = [
  "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.84.1",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "syn 2.0.98",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "frame-support",
  "frame-support-test-pallet",
  "frame-system",
@@ -3653,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3665,8 +3822,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3678,15 +3835,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "sp-version",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3699,8 +3855,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3709,8 +3865,8 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.46.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3776,9 +3932,9 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.1.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07bbbe7d7e78809544c6f718d875627addc73a7c3582447abc052cd3dc67e0"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -3854,17 +4010,18 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "futures-rustls"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.21.12",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3945,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3958,14 +4115,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3974,8 +4133,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4001,19 +4160,13 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator 0.3.0",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -4036,7 +4189,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -4048,7 +4201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -4064,7 +4217,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4073,17 +4226,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.1",
+ "http 1.3.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4147,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -4190,6 +4343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,6 +4361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec 0.7.6",
+]
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,21 +4377,22 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad3d6d98c648ed628df039541a5577bee1a7c83e9e16fe3dbedeea4cdfeb971"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.6.1",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 1.0.3",
+ "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -4233,9 +4402,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf287bde7b776e85d7188e6e5db7cf410a2f9531fe82817eb87feed034c8d14"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4244,7 +4413,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -4292,17 +4461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4315,9 +4473,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -4342,27 +4500,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -4372,9 +4530,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -4393,7 +4551,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -4409,8 +4567,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
- "http 1.2.0",
+ "h2 0.4.10",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -4423,53 +4581,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.23",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -4477,16 +4620,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.1",
 ]
 
 [[package]]
@@ -4500,21 +4644,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4524,30 +4669,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -4555,65 +4680,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -4621,27 +4733,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -4656,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4710,19 +4801,10 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -4756,15 +4838,6 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
@@ -4780,7 +4853,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4815,12 +4888,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -4831,9 +4904,9 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
 ]
@@ -4879,7 +4952,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4893,13 +4966,13 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4946,6 +5019,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4955,22 +5037,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4981,10 +5065,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -5000,104 +5085,38 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
- "jsonrpsee-client-transport 0.22.5",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-http-client",
- "jsonrpsee-types 0.22.5",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
-dependencies = [
- "jsonrpsee-core 0.23.2",
- "jsonrpsee-types 0.23.2",
- "jsonrpsee-ws-client 0.23.2",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
-dependencies = [
- "jsonrpsee-core 0.24.8",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.24.8",
- "jsonrpsee-ws-client 0.24.8",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-client",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.5"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "jsonrpsee-core 0.22.5",
- "pin-project",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "soketto 0.7.1",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.2.0",
- "jsonrpsee-core 0.23.2",
+ "http 1.3.1",
+ "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.23",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.1",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
-dependencies = [
- "base64 0.22.1",
- "futures-util",
- "http 1.2.0",
- "jsonrpsee-core 0.24.8",
- "pin-project",
- "rustls 0.23.23",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto 0.8.1",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "url",
@@ -5105,66 +5124,21 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.5"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
-dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "futures-timer",
- "futures-util",
- "hyper 0.14.32",
- "jsonrpsee-types 0.22.5",
- "pin-project",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
-dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "futures-timer",
- "futures-util",
- "jsonrpsee-types 0.23.2",
- "pin-project",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
+checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.24.8",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5175,52 +5149,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-http-client"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
-dependencies = [
- "async-trait",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-types 0.22.5",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcae0c6c159e11541080f1f829873d8f374f81eda0abc67695a13fc8dc1a580"
+checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7a3df90a1a60c3ed68e7ca63916b53e9afa928e33531e87f61a9c8e9ae87b"
+checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "jsonrpsee-core 0.24.8",
- "jsonrpsee-types 0.24.8",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -5236,37 +5190,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
-dependencies = [
- "beef",
- "http 1.2.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
-dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5274,27 +5202,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.23.2"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
- "http 1.2.0",
- "jsonrpsee-client-transport 0.23.2",
- "jsonrpsee-core 0.23.2",
- "jsonrpsee-types 0.23.2",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
-dependencies = [
- "http 1.2.0",
- "jsonrpsee-client-transport 0.24.8",
- "jsonrpsee-core 0.24.8",
- "jsonrpsee-types 0.24.8",
+ "http 1.3.1",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "url",
 ]
 
@@ -5309,7 +5224,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5323,11 +5238,11 @@ dependencies = [
 
 [[package]]
 name = "keccak-hash"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
 dependencies = [
- "primitive-types 0.12.2",
+ "primitive-types",
  "tiny-keccak",
 ]
 
@@ -5395,38 +5310,37 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
-version = "0.52.4"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
+checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
 dependencies = [
  "bytes",
  "either",
  "futures 0.3.31",
  "futures-timer",
- "getrandom 0.2.15",
- "instant",
+ "getrandom 0.2.16",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
@@ -5443,7 +5357,6 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
- "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr 0.18.2",
@@ -5454,9 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
+checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5466,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
+checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5478,17 +5391,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.40.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
+checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
- "instant",
  "libp2p-identity",
- "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
  "multistream-select",
@@ -5496,37 +5407,39 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
  "thiserror 1.0.69",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint 0.8.0",
  "void",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.40.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
+checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
+ "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
- "log",
  "parking_lot 0.12.3",
  "smallvec",
- "trust-dns-resolver",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.43.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
+checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "either",
  "futures 0.3.31",
  "futures-bounded",
@@ -5534,148 +5447,150 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
  "lru 0.12.5",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
  "thiserror 1.0.69",
+ "tracing",
  "void",
 ]
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash 0.19.3",
  "quick-protobuf",
- "rand",
- "sha2 0.10.8",
- "thiserror 1.0.69",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.44.6"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
+checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
 dependencies = [
  "arrayvec 0.7.6",
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "either",
  "fnv",
  "futures 0.3.31",
+ "futures-bounded",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
- "sha2 0.10.8",
+ "rand 0.8.5",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 1.0.69",
+ "tracing",
  "uint 0.9.5",
- "unsigned-varint 0.7.2",
  "void",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
+checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
 dependencies = [
  "data-encoding",
  "futures 0.3.31",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
- "trust-dns-proto 0.22.0",
+ "tracing",
  "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
+checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
- "instant",
+ "futures 0.3.31",
  "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
  "libp2p-swarm",
- "once_cell",
+ "pin-project",
  "prometheus-client",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.43.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
+checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
 dependencies = [
+ "asynchronous-codec 0.7.0",
  "bytes",
  "curve25519-dalek",
  "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
- "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
  "once_cell",
  "quick-protobuf",
- "rand",
- "sha2 0.10.8",
+ "rand 0.8.5",
+ "sha2 0.10.9",
  "snow",
  "static_assertions",
  "thiserror 1.0.69",
+ "tracing",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.43.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
+checksum = "005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422"
 dependencies = [
  "either",
  "futures 0.3.31",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
- "rand",
+ "rand 0.8.5",
+ "tracing",
  "void",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-quic"
-version = "0.9.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
+checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
 dependencies = [
  "bytes",
  "futures 0.3.31",
@@ -5684,76 +5599,78 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "log",
  "parking_lot 0.12.3",
  "quinn",
- "rand",
- "ring 0.16.20",
- "rustls 0.21.12",
- "socket2 0.5.8",
+ "rand 0.8.5",
+ "ring 0.17.14",
+ "rustls",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
+checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
- "instant",
+ "futures-bounded",
+ "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
+ "tracing",
  "void",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.7"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
+checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "log",
+ "lru 0.12.5",
  "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
+ "tracing",
  "void",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
+checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-warning 0.4.2",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.40.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
+checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -5761,92 +5678,80 @@ dependencies = [
  "libc",
  "libp2p-core",
  "libp2p-identity",
- "log",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.2.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
+checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
- "ring 0.16.20",
- "rustls 0.21.12",
+ "ring 0.17.14",
+ "rustls",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
- "x509-parser 0.15.1",
+ "x509-parser 0.16.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
+checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "igd-next",
  "libp2p-core",
  "libp2p-swarm",
- "log",
  "tokio",
+ "tracing",
  "void",
 ]
 
 [[package]]
-name = "libp2p-wasm-ext"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
-dependencies = [
- "futures 0.3.31",
- "js-sys",
- "libp2p-core",
- "send_wrapper",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "libp2p-websocket"
-version = "0.42.2"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
+checksum = "888b2ff2e5d8dcef97283daab35ad1043d18952b65e05279eecbe02af4c6e347"
 dependencies = [
  "either",
  "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "log",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "rw-stream-sink",
  "soketto 0.8.1",
  "thiserror 1.0.69",
+ "tracing",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.44.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
+checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
 dependencies = [
+ "either",
  "futures 0.3.31",
  "libp2p-core",
- "log",
  "thiserror 1.0.69",
- "yamux",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.5",
 ]
 
 [[package]]
@@ -5855,9 +5760,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -5877,18 +5782,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.13.1",
+ "base64 0.22.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -5925,9 +5830,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5936,9 +5841,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
 dependencies = [
  "cc",
 ]
@@ -5986,6 +5891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lioness"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5999,58 +5910,53 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litep2p"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca6ee50a125dc4fc4e9a3ae3640010796d1d07bc517a0ac715fdf0b24a0b6ac"
+checksum = "d71056c23c896bb0e18113b2d2f1989be95135e6bdeedb0b757422ee21a073eb"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures 0.3.31",
  "futures-timer",
- "hex-literal",
  "hickory-resolver",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "libc",
- "mockall 0.13.1",
+ "mockall",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
- "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
  "prost-build",
- "rand",
- "rcgen",
- "ring 0.16.20",
- "rustls 0.20.9",
+ "rand 0.8.5",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.8",
- "static_assertions",
- "thiserror 1.0.69",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uint 0.9.5",
+ "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
- "x509-parser 0.16.0",
+ "x509-parser 0.17.0",
+ "yamux 0.13.5",
  "yasna",
  "zeroize",
 ]
@@ -6067,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -6083,7 +5989,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -6094,6 +6000,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -6132,7 +6044,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6146,7 +6058,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6157,7 +6069,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6168,14 +6080,8 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -6187,16 +6093,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matrixmultiply"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -6255,15 +6155,15 @@ dependencies = [
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c592efaf1b3250df14c8f3c2d952233f0302bb81d3586db2f303666c1cd607"
+checksum = "dc9b7ac0ce054412d9a85ff39bac27aec27483b06cef8756b57d9c29d448d081"
 dependencies = [
  "array-bytes",
  "blake3",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
- "scale-decode",
+ "scale-decode 0.13.1",
  "scale-info",
 ]
 
@@ -6275,7 +6175,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -6287,9 +6187,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -6322,8 +6222,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.6.1",
  "thiserror 1.0.69",
@@ -6332,8 +6232,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "44.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -6351,10 +6251,10 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -6366,21 +6266,6 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive 0.11.4",
- "predicates 2.1.5",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
@@ -6388,21 +6273,9 @@ dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "mockall_derive 0.13.1",
- "predicates 3.1.3",
+ "mockall_derive",
+ "predicates",
  "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6414,7 +6287,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6434,13 +6307,13 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
  "cumulus-relay-chain-rpc-interface",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "flume",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures 0.3.31",
  "hex-literal",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "moonkit-template-runtime",
  "nimbus-consensus",
@@ -6547,6 +6420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6607,24 +6486,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "unsigned-varint 0.7.2",
 ]
@@ -6655,9 +6517,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multistream-select"
@@ -6694,7 +6556,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6703,7 +6565,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -6754,7 +6616,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6772,9 +6634,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "c3329f515506e4a2de3aa6e07027a6758e22e0f0e8eaf64fa47261cec2282602"
 dependencies = [
  "cc",
  "libc",
@@ -6851,13 +6713,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -6908,12 +6770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6947,6 +6803,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "num-format"
@@ -7013,10 +6880,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7033,29 +6900,11 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs 0.5.2",
 ]
 
 [[package]]
@@ -7068,10 +6917,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.3"
+name = "oid-registry"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.1",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -7121,10 +6979,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.11.0",
  "petgraph 0.6.5",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7138,8 +6996,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7156,8 +7014,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7170,8 +7028,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7187,8 +7045,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "42.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7298,8 +7156,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7313,8 +7171,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7326,8 +7184,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7349,8 +7207,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7370,8 +7228,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7380,13 +7238,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "sp-core",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7404,8 +7263,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7429,8 +7288,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "38.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7446,8 +7305,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7464,8 +7323,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7482,8 +7341,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "21.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7493,33 +7352,16 @@ dependencies = [
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-runtime",
  "sp-staking",
 ]
 
 [[package]]
-name = "pallet-collective"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-conviction-voting"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7534,8 +7376,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7549,8 +7391,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7566,8 +7408,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7576,7 +7418,7 @@ dependencies = [
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -7588,8 +7430,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7601,8 +7443,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7641,8 +7483,9 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#4dddde8766dc23337ade83fbd5836dd9e4d7326d"
+source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
 dependencies = [
+ "cumulus-primitives-storage-weight-reclaim",
  "environmental",
  "evm",
  "fp-account",
@@ -7665,7 +7508,7 @@ dependencies = [
 name = "pallet-evm-precompile-balances-erc20"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -7693,7 +7536,7 @@ dependencies = [
 name = "pallet-evm-precompile-batch"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "evm",
  "fp-evm",
  "frame-support",
@@ -7721,7 +7564,7 @@ dependencies = [
 name = "pallet-evm-precompile-call-permit"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "evm",
  "fp-evm",
  "frame-support",
@@ -7750,7 +7593,7 @@ dependencies = [
 name = "pallet-evm-precompile-proxy"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "evm",
  "fp-evm",
  "frame-support",
@@ -7778,7 +7621,7 @@ name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "evm",
  "fp-evm",
  "frame-support",
@@ -7810,7 +7653,7 @@ name = "pallet-evm-precompile-xcm-utils"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -7862,8 +7705,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7901,8 +7744,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7923,8 +7766,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7939,8 +7782,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7958,8 +7801,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7968,21 +7811,18 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "frame-support",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "safe-mix",
  "scale-info",
- "sp-runtime",
 ]
 
 [[package]]
@@ -8004,8 +7844,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8020,8 +7860,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "43.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8035,6 +7875,24 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-meta-tx"
+version = "0.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8060,10 +7918,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-migrations"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "10.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "cfg-if",
  "docify",
  "frame-benchmarking",
  "frame-support",
@@ -8071,32 +7928,29 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
  "sp-core",
+ "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "log",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-core",
- "sp-io",
  "sp-mmr-primitives",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8106,23 +7960,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8139,8 +7988,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "38.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8159,8 +8008,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8169,13 +8018,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -8185,8 +8033,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8208,8 +8056,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.11.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8225,8 +8073,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8241,8 +8089,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8253,7 +8101,7 @@ dependencies = [
 name = "pallet-randomness"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "environmental",
  "frame-benchmarking",
  "frame-support",
@@ -8277,8 +8125,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8295,8 +8143,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8309,8 +8157,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8331,7 +8179,7 @@ version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "environmental",
  "frame-benchmarking",
  "frame-support",
@@ -8352,8 +8200,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8366,8 +8214,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8383,8 +8231,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8404,8 +8252,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8413,22 +8261,22 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "sp-runtime",
  "sp-session",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
@@ -8437,8 +8285,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8448,7 +8296,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -8459,8 +8307,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -8468,8 +8316,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8478,8 +8326,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "44.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8494,8 +8342,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8524,8 +8372,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8543,8 +8391,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,8 +8409,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8577,10 +8425,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "43.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -8593,8 +8441,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8605,8 +8453,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8624,8 +8472,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8638,9 +8486,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-verify-signature"
+version = "0.3.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
 name = "pallet-vesting"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8653,22 +8517,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-api",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -8690,13 +8550,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -8708,8 +8567,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "21.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -8733,7 +8592,6 @@ dependencies = [
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
- "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -8742,9 +8600,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
- "bitcoin_hashes",
- "rand",
- "rand_core",
+ "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -8764,7 +8622,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -8773,8 +8631,7 @@ dependencies = [
 [[package]]
 name = "parity-scale-codec"
 version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+source = "git+https://github.com/paritytech/parity-scale-codec?rev=334b99c9cc8def7408bcd91d1ff7bfd79f7e2915#334b99c9cc8def7408bcd91d1ff7bfd79f7e2915"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -8790,13 +8647,12 @@ dependencies = [
 [[package]]
 name = "parity-scale-codec-derive"
 version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+source = "git+https://github.com/paritytech/parity-scale-codec?rev=334b99c9cc8def7408bcd91d1ff7bfd79f7e2915#334b99c9cc8def7408bcd91d1ff7bfd79f7e2915"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8854,7 +8710,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -8872,7 +8728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -8889,6 +8745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "hmac 0.12.1",
  "password-hash",
 ]
 
@@ -8900,11 +8757,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -8915,20 +8773,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -8936,26 +8794,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8965,7 +8823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -8975,27 +8833,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9033,16 +8891,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "bitvec",
  "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
@@ -9052,32 +8909,30 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "always-assert",
  "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "parity-scale-codec",
@@ -9087,7 +8942,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "sp-core",
@@ -9098,8 +8953,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9111,7 +8966,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "thiserror 1.0.69",
@@ -9121,9 +8976,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-ckb-merkle-mountain-range"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b44320e5f7ce2c18227537a3032ae5b2c476a7e8eddba45333e1011fc31b92"
+checksum = "221c71b432b38e494a0fdedb5f720e4cb974edf03a0af09e5b2238dbac7e6947"
 dependencies = [
  "cfg-if",
  "itertools 0.10.5",
@@ -9131,10 +8986,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "cfg-if",
  "clap",
  "frame-benchmarking-cli",
  "futures 0.3.31",
@@ -9143,15 +8997,12 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-service",
  "sc-cli",
- "sc-executor",
  "sc-service",
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io",
  "sp-keyring",
- "sp-maybe-compressed-blob",
  "sp-runtime",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
@@ -9159,8 +9010,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9182,8 +9033,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "17.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9193,23 +9044,20 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "parity-scale-codec",
- "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sc-network",
- "schnellru",
  "sp-application-crypto",
  "sp-keystore",
  "thiserror 1.0.69",
@@ -9218,8 +9066,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9232,8 +9080,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -9241,21 +9089,20 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sc-network",
- "sc-network-common",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-keystore",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -9277,8 +9124,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -9289,23 +9136,21 @@ dependencies = [
  "polkadot-primitives",
  "schnellru",
  "sp-core",
- "sp-maybe-compressed-blob",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
- "kvdb",
  "merlin",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9313,9 +9158,9 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
@@ -9329,12 +9174,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.5.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
- "futures-timer",
  "itertools 0.11.0",
  "polkadot-approval-distribution",
  "polkadot-node-core-approval-voting",
@@ -9345,33 +9189,26 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "sc-keystore",
- "sp-application-crypto",
  "sp-consensus",
- "sp-consensus-slots",
- "sp-runtime",
- "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
  "futures-timer",
- "kvdb",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
  "polkadot-primitives",
  "sp-consensus",
  "thiserror 1.0.69",
@@ -9380,8 +9217,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9401,8 +9238,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -9416,8 +9253,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9438,8 +9275,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9452,12 +9289,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
- "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -9469,12 +9305,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "fatality",
  "futures 0.3.31",
- "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -9488,8 +9323,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9505,8 +9340,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "21.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9519,8 +9354,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9530,32 +9365,29 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "schnellru",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "always-assert",
  "array-bytes",
- "blake3",
- "cfg-if",
  "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
+ "sc-tracing",
  "slotmap",
  "sp-core",
  "strum 0.26.3",
@@ -9567,30 +9399,27 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
- "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
  "polkadot-primitives",
  "sp-keystore",
- "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
  "landlock",
  "libc",
- "nix 0.28.0",
+ "nix 0.29.0",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
@@ -9599,7 +9428,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -9609,8 +9438,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9624,13 +9453,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bs58",
  "futures 0.3.31",
  "futures-timer",
- "log",
  "parity-scale-codec",
  "polkadot-primitives",
  "prioritized-metered-channel",
@@ -9638,25 +9466,24 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "substrate-prometheus-endpoint",
- "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures 0.3.31",
  "hex",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
@@ -9668,8 +9495,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9684,18 +9511,16 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -9703,12 +9528,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
- "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures 0.3.31",
  "orchestra",
@@ -9732,20 +9556,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "async-trait",
- "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
- "futures-channel",
  "itertools 0.11.0",
  "kvdb",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "pin-project",
  "polkadot-erasure-coding",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -9755,7 +9575,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "schnellru",
  "sp-application-crypto",
@@ -9767,21 +9587,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
  "orchestra",
- "parking_lot 0.12.3",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
@@ -9789,11 +9607,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "16.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "scale-info",
@@ -9805,8 +9623,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "18.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -9833,10 +9651,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -9846,11 +9664,9 @@ dependencies = [
  "sc-consensus-babe-rpc",
  "sc-consensus-beefy",
  "sc-consensus-beefy-rpc",
- "sc-consensus-epochs",
  "sc-consensus-grandpa",
  "sc-consensus-grandpa-rpc",
  "sc-rpc",
- "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
  "sp-api",
@@ -9868,8 +9684,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9900,7 +9716,6 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "serde_derive",
  "slot-range-helper",
  "sp-api",
  "sp-core",
@@ -9919,8 +9734,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9931,12 +9746,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.19",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -9952,14 +9766,13 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "pallet-timestamp",
- "pallet-vesting",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
  "sp-api",
@@ -9979,9 +9792,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-sdk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb819108697967452fa6d8d96ab4c0d48cbaa423b3156499dcb24f1cf95d6775"
+dependencies = [
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "polkadot-sdk-frame"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.9.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9994,6 +9816,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
@@ -10014,8 +9837,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10122,15 +9945,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "fatality",
  "futures 0.3.31",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -10145,20 +9968,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-core",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkavm"
-version = "0.9.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3693e5efdb2bf74e449cd25fd777a28bd7ed87e41f5d5da75eb31b4de48b94"
+checksum = "dd044ab1d3b11567ab6b98ca71259a992b4034220d5972988a0e96518e5d343d"
 dependencies = [
  "libc",
  "log",
@@ -10169,63 +9991,65 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa96d6d868243acc12de813dd48e756cbadcc8e13964c70d272753266deadc1"
+checksum = "eaad38dc420bfed79e6f731471c973ce5ff5e47ab403e63cf40358fef8a6368f"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-common"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
+checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
 dependencies = [
  "log",
+ "polkavm-assembler",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.9.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
+checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.9.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
+checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
+checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.9.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
+checksum = "e9bfe793b094d9ea5c99b7c43ba46e277b0f8f48f4bbfdbabf8d3ebf701a4bd3"
 dependencies = [
- "gimli 0.28.1",
+ "dirs",
+ "gimli 0.31.1",
  "hashbrown 0.14.5",
  "log",
- "object 0.32.2",
+ "object 0.36.7",
  "polkavm-common",
  "regalloc2 0.9.3",
  "rustc-demangle",
@@ -10233,9 +10057,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
+checksum = "23eff02c070c70f31878a3d915e88a914ecf3e153741e2fb572dde28cce20fde"
 
 [[package]]
 name = "polling"
@@ -10293,9 +10117,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -10305,9 +10138,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -10315,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#4dddde8766dc23337ade83fbd5836dd9e4d7326d"
+source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10344,29 +10177,15 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#4dddde8766dc23337ade83fbd5836dd9e4d7326d"
+source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
 dependencies = [
  "case",
  "num_enum",
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10407,25 +10226,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.6.0",
- "impl-serde 0.4.0",
- "scale-info",
- "uint 0.9.5",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10435,10 +10241,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-num-traits",
  "impl-rlp",
- "impl-serde 0.5.0",
+ "impl-serde",
  "scale-info",
  "uint 0.10.0",
 ]
@@ -10451,7 +10257,7 @@ checksum = "a172e6cc603231f2cf004232eabcecccc0da53ba576ab286ef7baa0cfc7927ad"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures 0.3.31",
  "futures-timer",
  "nanorand",
@@ -10471,9 +10277,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -10503,14 +10309,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-warning"
-version = "0.4.2"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10521,14 +10338,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -10549,9 +10366,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -10567,7 +10384,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10576,11 +10393,11 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "unarray",
@@ -10622,7 +10439,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -10636,7 +10453,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10649,7 +10466,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10663,9 +10480,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -10686,12 +10503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10702,73 +10513,87 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
+ "cfg_aliases 0.2.1",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "thiserror 1.0.69",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.6"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "rand",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring 0.17.14",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.4.1"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
- "bytes",
+ "cfg_aliases 0.2.1",
  "libc",
- "socket2 0.5.8",
+ "once_cell",
+ "socket2 0.5.9",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -10783,8 +10608,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -10794,7 +10629,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -10803,7 +10648,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -10813,7 +10667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10822,7 +10676,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10831,16 +10685,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -10871,30 +10725,14 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
  "pem",
  "ring 0.16.20",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "reconnecting-jsonrpsee-ws-client"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fa4f17e09edfc3131636082faaec633c7baa269396b4004040bc6c52f49f65"
-dependencies = [
- "cfg_aliases 0.2.1",
- "finito",
- "futures 0.3.31",
- "jsonrpsee 0.23.2",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -10908,11 +10746,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -10921,7 +10759,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -10932,7 +10770,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87413ebb313323d431e85d0afc5a68222aaed972843537cbfe5f061cf1b4bcab"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fs-err",
  "static_init",
  "thiserror 1.0.69",
@@ -10940,22 +10778,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11029,13 +10867,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
-]
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "rfc6979"
@@ -11064,13 +10898,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -11104,7 +10938,7 @@ checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11119,8 +10953,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -11143,16 +10977,14 @@ dependencies = [
  "pallet-beefy-mmr",
  "pallet-bounties",
  "pallet-child-bounties",
- "pallet-collective",
  "pallet-conviction-voting",
  "pallet-democracy",
  "pallet-elections-phragmen",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-indices",
- "pallet-membership",
  "pallet-message-queue",
- "pallet-migrations 9.0.0",
+ "pallet-migrations 10.1.0",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nis",
@@ -11190,7 +11022,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
@@ -11214,15 +11045,14 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
- "static_assertions",
  "substrate-wasm-builder",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11243,13 +11073,13 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11272,12 +11102,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11319,7 +11149,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -11365,88 +11195,39 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.9"
+name = "rustix"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.9",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.9",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle 2.6.1",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.9",
+ "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle 2.6.1",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -11458,52 +11239,38 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.9.4",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.23",
- "rustls-native-certs 0.7.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.8",
- "security-framework 2.11.1",
+ "rustls-webpki 0.103.3",
+ "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.8",
- "winapi",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11518,26 +11285,26 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ruzstd"
@@ -11552,13 +11319,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.19",
- "twox-hash",
+ "derive_more 0.99.20",
 ]
 
 [[package]]
@@ -11574,9 +11340,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe-mix"
@@ -11597,6 +11363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11607,8 +11382,8 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "31.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "sp-core",
@@ -11618,21 +11393,19 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
  "ip_network",
- "libp2p",
  "linked_hash_set",
  "log",
- "multihash 0.19.3",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -11648,11 +11421,10 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
- "futures-timer",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -11670,8 +11442,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.44.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11685,12 +11457,11 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "42.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "docify",
- "log",
  "memmap2 0.9.5",
  "parity-scale-codec",
  "sc-chain-spec-derive",
@@ -11702,7 +11473,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -11713,18 +11484,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.51.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -11737,7 +11508,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -11765,8 +11536,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -11784,7 +11555,6 @@ dependencies = [
  "sp-externalities",
  "sp-runtime",
  "sp-state-machine",
- "sp-statement-store",
  "sp-storage",
  "sp-trie",
  "substrate-prometheus-endpoint",
@@ -11792,8 +11562,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.46.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11818,19 +11588,18 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "log",
- "mockall 0.11.4",
+ "mockall",
  "parking_lot 0.12.3",
  "sc-client-api",
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
@@ -11842,8 +11611,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11871,8 +11640,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11897,7 +11666,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -11907,11 +11676,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -11929,13 +11698,12 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
- "fnv",
  "futures 0.3.31",
  "log",
  "parity-scale-codec",
@@ -11954,7 +11722,6 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -11965,11 +11732,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11985,8 +11752,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11998,8 +11765,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12012,7 +11779,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -12033,7 +11800,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -12042,12 +11809,12 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -12062,14 +11829,14 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.50.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "assert_matches",
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -12097,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12120,8 +11887,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.42.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12143,8 +11910,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.38.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -12156,8 +11923,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "polkavm",
@@ -12167,12 +11934,10 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.38.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "anyhow",
- "cfg-if",
- "libc",
  "log",
  "parking_lot 0.12.3",
  "rustix 0.36.17",
@@ -12185,8 +11950,8 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -12194,7 +11959,6 @@ dependencies = [
  "log",
  "sc-client-api",
  "sc-network",
- "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
  "sp-runtime",
@@ -12202,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "35.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -12216,8 +11980,8 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -12227,7 +11991,6 @@ dependencies = [
  "futures-timer",
  "log",
  "mixnet",
- "multiaddr 0.18.2",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-client-api",
@@ -12245,13 +12008,13 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.48.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.2",
  "bytes",
  "cid 0.9.0",
  "either",
@@ -12263,15 +12026,14 @@ dependencies = [
  "linked_hash_set",
  "litep2p",
  "log",
- "mockall 0.11.4",
- "once_cell",
+ "mockall",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sc-network-types",
@@ -12296,26 +12058,18 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "async-trait",
  "bitflags 1.3.2",
- "futures 0.3.31",
- "libp2p-identity",
  "parity-scale-codec",
- "prost-build",
- "sc-consensus",
- "sc-network-types",
- "sp-consensus",
- "sp-consensus-grandpa",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -12333,8 +12087,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12354,17 +12108,16 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
  "futures 0.3.31",
- "futures-timer",
  "log",
- "mockall 0.11.4",
+ "mockall",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
@@ -12390,8 +12143,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -12409,45 +12162,44 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.15.3"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bs58",
+ "bytes",
  "ed25519-dalek",
  "libp2p-identity",
+ "libp2p-kad",
  "litep2p",
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "44.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "array-bytes",
  "bytes",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls",
  "hyper-util",
- "log",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
- "rustls 0.23.23",
+ "rand 0.8.5",
+ "rustls",
  "sc-client-api",
  "sc-network",
- "sc-network-common",
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -12463,8 +12215,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.20.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12472,11 +12224,11 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "44.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12504,10 +12256,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.48.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-mixnet",
@@ -12524,18 +12276,18 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "21.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
  "futures 0.3.31",
  "governor",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "ip_network",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "sc-rpc-api",
  "serde",
@@ -12548,19 +12300,19 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
  "futures-util",
  "hex",
  "itertools 0.11.0",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
@@ -12579,21 +12331,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-runtime-utilities"
+version = "0.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+dependencies = [
+ "parity-scale-codec",
+ "sc-executor",
+ "sc-executor-common",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
+ "sp-state-machine",
+ "sp-wasm-interface",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "sc-service"
-version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.50.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures 0.3.31",
  "futures-timer",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -12644,8 +12411,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.37.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.38.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12655,8 +12422,8 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.24.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "clap",
  "fs4",
@@ -12668,10 +12435,10 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.49.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -12687,29 +12454,28 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "42.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures 0.3.31",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-io",
- "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "28.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -12717,8 +12483,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "sc-network",
+ "rand 0.8.5",
  "sc-utils",
  "serde",
  "serde_json",
@@ -12728,8 +12493,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "chrono",
  "console",
@@ -12756,24 +12521,24 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing-proc-macro"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "11.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
@@ -12786,7 +12551,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -12794,15 +12559,17 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
+ "indexmap 2.9.0",
  "log",
  "parity-scale-codec",
  "serde",
@@ -12814,8 +12581,8 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "18.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -12844,9 +12611,22 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
- "primitive-types 0.12.2",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ae9cc099ae85ff28820210732b00f019546f36f33225f509fe25d5816864a0"
+dependencies = [
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "primitive-types",
  "scale-bits",
  "scale-decode-derive",
  "scale-type-resolver",
@@ -12855,25 +12635,25 @@ dependencies = [
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb22f574168103cdd3133b19281639ca65ad985e24612728f727339dcaf4021"
+checksum = "5ed9401effa946b493f9f84dc03714cca98119b230497df6f3df6b84a2b03648"
 dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "scale-encode"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528464e6ae6c8f98e2b79633bf79ef939552e795e316579dab09c61670d56602"
+checksum = "5f9271284d05d0749c40771c46180ce89905fd95aa72a2a2fddb4b7c0aa424db"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 1.0.0",
  "parity-scale-codec",
- "primitive-types 0.12.2",
+ "primitive-types",
  "scale-bits",
  "scale-encode-derive",
  "scale-type-resolver",
@@ -12882,15 +12662,15 @@ dependencies = [
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef2618f123c88da9cd8853b69d766068f1eddc7692146d7dfe9b89e25ce2efd"
+checksum = "102fbc6236de6c53906c0b262f12c7aa69c2bdc604862c12728f5f4d370bc137"
 dependencies = [
- "darling 0.20.10",
- "proc-macro-crate 3.2.0",
+ "darling",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12913,10 +12693,10 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12931,31 +12711,30 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498d1aecf2ea61325d4511787c115791639c0fd21ef4f8e11e49dd09eff2bbac"
+checksum = "0dc4c70c7fea2eef1740f0081d3fe385d8bee1eef11e9272d3bec7dc8e5438e0"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.98",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6ab090d823e75cfdb258aad5fe92e13f2af7d04b43a55d607d25fcc38c811"
+checksum = "f5e0ef2a0ee1e02a69ada37feb87ea1616ce9808aca072befe2d3131bf28576e"
 dependencies = [
  "base58",
  "blake2 0.10.6",
- "derive_more 0.99.19",
+ "derive_more 1.0.0",
  "either",
- "frame-metadata 15.1.0",
  "parity-scale-codec",
  "scale-bits",
- "scale-decode",
+ "scale-decode 0.14.0",
  "scale-encode",
  "scale-info",
  "scale-type-resolver",
@@ -12993,7 +12772,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "curve25519-dalek-ng",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "subtle-ng",
  "zeroize",
@@ -13011,9 +12790,9 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -13026,18 +12805,20 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "scrypt"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "ring 0.17.9",
- "untrusted 0.9.0",
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -13083,6 +12864,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13101,6 +12893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13110,17 +12911,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "secrecy"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "num-bigint",
- "security-framework-sys",
+ "zeroize",
 ]
 
 [[package]]
@@ -13129,7 +12925,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -13166,9 +12962,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -13180,45 +12976,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -13303,9 +13093,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -13339,9 +13129,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -13353,7 +13143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -13381,9 +13171,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f08357795f0d604ea7d7130f22c74b03838c959bdb14adde3142aab4d18a293"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
  "console",
  "similar",
@@ -13391,11 +13181,11 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -13445,8 +13235,8 @@ dependencies = [
 
 [[package]]
 name = "slot-range-helper"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13465,9 +13255,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
@@ -13518,7 +13308,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener 2.5.3",
@@ -13539,54 +13329,53 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "ruzstd 0.4.0",
  "schnorrkel 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "siphasher 0.3.11",
  "slab",
  "smallvec",
  "soketto 0.7.1",
  "twox-hash",
- "wasmi",
+ "wasmi 0.31.2",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "smoldot"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d1eaa97d77be4d026a1e7ffad1bb3b78448763b357ea6f8188d3e6f736a9b9"
+checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock 3.4.0",
  "atomic-take",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bip39",
  "blake2-rfc",
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
- "event-listener 4.0.3",
+ "event-listener 5.4.0",
  "fnv",
  "futures-lite 2.6.0",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
  "hmac 0.12.1",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libm",
  "libsecp256k1",
  "merlin",
- "no-std-net",
  "nom",
  "num-bigint",
  "num-rational",
@@ -13594,20 +13383,20 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
- "ruzstd 0.5.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd 0.6.0",
  "schnorrkel 0.11.4",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "siphasher 1.0.1",
  "slab",
  "smallvec",
- "soketto 0.7.1",
+ "soketto 0.8.1",
  "twox-hash",
- "wasmi",
+ "wasmi 0.32.3",
  "x25519-dalek",
  "zeroize",
 ]
@@ -13622,7 +13411,7 @@ dependencies = [
  "async-lock 2.8.0",
  "base64 0.21.7",
  "blake2-rfc",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener 2.5.3",
  "fnv",
@@ -13637,8 +13426,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 0.3.11",
@@ -13650,37 +13439,37 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.14.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5496f2d116b7019a526b1039ec2247dd172b8670633b1a64a614c9ea12c9d8c7"
+checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
 dependencies = [
  "async-channel 2.3.1",
  "async-lock 3.4.0",
- "base64 0.21.7",
+ "base64 0.22.1",
  "blake2-rfc",
- "derive_more 0.99.19",
+ "bs58",
+ "derive_more 0.99.20",
  "either",
- "event-listener 4.0.3",
+ "event-listener 5.4.0",
  "fnv",
  "futures-channel",
  "futures-lite 2.6.0",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "lru 0.12.5",
- "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 1.0.1",
  "slab",
  "smol 2.0.2",
- "smoldot 0.16.0",
+ "smoldot 0.18.0",
  "zeroize",
 ]
 
@@ -13700,10 +13489,10 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
- "ring 0.17.9",
+ "rand_core 0.6.4",
+ "ring 0.17.14",
  "rustc_version 0.4.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
 ]
 
@@ -13719,9 +13508,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -13738,7 +13527,7 @@ dependencies = [
  "futures 0.3.31",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1",
 ]
 
@@ -13751,17 +13540,17 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures 0.3.31",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
 [[package]]
 name = "sp-api"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "36.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "hash-db",
@@ -13782,22 +13571,22 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13808,8 +13597,8 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "26.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13822,8 +13611,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13834,8 +13623,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13844,8 +13633,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -13863,13 +13652,12 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.42.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "log",
- "sp-core",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -13878,8 +13666,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.42.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13894,8 +13682,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.42.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13912,8 +13700,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "24.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13921,7 +13709,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -13932,8 +13720,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "23.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13949,8 +13737,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.42.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13960,9 +13748,10 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "36.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
+ "ark-vrf",
  "array-bytes",
  "bitflags 1.3.2",
  "blake2 0.10.6",
@@ -13973,7 +13762,7 @@ dependencies = [
  "futures 0.3.31",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde 0.5.0",
+ "impl-serde",
  "itertools 0.11.0",
  "k256",
  "libsecp256k1",
@@ -13983,14 +13772,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
- "primitive-types 0.13.1",
- "rand",
+ "primitive-types",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1 0.28.2",
- "secrecy",
+ "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -14013,7 +13802,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "twox-hash",
 ]
@@ -14021,12 +13810,12 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "twox-hash",
 ]
@@ -14034,17 +13823,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "syn 2.0.98",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14053,17 +13842,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14072,8 +13861,8 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14084,8 +13873,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14097,8 +13886,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "40.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bytes",
  "docify",
@@ -14110,7 +13899,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -14123,8 +13912,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "41.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14133,8 +13922,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "0.42.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14145,7 +13934,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -14153,18 +13942,18 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "0.10.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
 
 [[package]]
 name = "sp-mixnet"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.14.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14174,8 +13963,8 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14191,8 +13980,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14204,8 +13993,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14214,8 +14003,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "13.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "backtrace",
  "regex",
@@ -14223,8 +14012,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "34.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14233,8 +14022,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "41.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -14245,7 +14034,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -14262,14 +14051,14 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "29.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive",
- "primitive-types 0.13.1",
+ "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -14282,20 +14071,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-session"
-version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14308,8 +14097,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "38.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -14321,14 +14110,14 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "0.45.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -14341,21 +14130,21 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -14366,14 +14155,14 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -14382,8 +14171,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14394,8 +14183,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "17.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -14405,8 +14194,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14414,8 +14203,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "36.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14428,8 +14217,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "ahash",
  "hash-db",
@@ -14437,7 +14226,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
@@ -14450,10 +14239,10 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
@@ -14468,19 +14257,19 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-warning 1.84.1",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14491,8 +14280,8 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "31.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14560,8 +14349,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.20.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14573,12 +14362,12 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "16.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "bounded-collections",
- "derivative",
+ "derive-where",
  "environmental",
  "frame-support",
  "hex-literal",
@@ -14594,30 +14383,32 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
+ "environmental",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log",
  "pallet-asset-conversion",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-executor",
+ "tracing",
 ]
 
 [[package]]
 name = "staging-xcm-executor"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14669,10 +14460,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "string-interner"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "strsim"
@@ -14718,35 +14513,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "schnorrkel 0.11.4",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "43.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
  "futures 0.3.31",
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
@@ -14760,8 +14555,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.17.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -14774,10 +14569,10 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "42.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
- "jsonrpsee 0.24.8",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -14792,7 +14587,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14802,7 +14597,6 @@ dependencies = [
  "sc-client-db",
  "sc-consensus",
  "sc-executor",
- "sc-offchain",
  "sc-service",
  "serde",
  "serde_json",
@@ -14812,14 +14606,13 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
- "sp-state-machine",
  "tokio",
 ]
 
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -14842,7 +14635,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
  "sp-externalities",
  "sp-genesis-builder",
  "sp-inherents",
@@ -14863,7 +14656,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "futures 0.3.31",
  "sc-block-builder",
@@ -14880,15 +14673,15 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "26.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "jobserver",
  "merkleized-metadata",
  "parity-scale-codec",
@@ -14903,7 +14696,7 @@ dependencies = [
  "sp-version",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
  "wasm-opt",
 ]
@@ -14928,99 +14721,97 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a160cba1edbf3ec4fbbeaea3f1a185f70448116a6bccc8276bb39adb3b3053bd"
+checksum = "1c17d7ec2359d33133b63c97e28c8b7cd3f0a5bc6ce567ae3aef9d9e85be3433"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 16.0.0",
+ "frame-metadata 17.0.0",
  "futures 0.3.31",
  "hex",
- "impl-serde 0.4.0",
- "instant",
- "jsonrpsee 0.22.5",
+ "impl-serde",
+ "jsonrpsee",
  "parity-scale-codec",
- "primitive-types 0.12.2",
- "reconnecting-jsonrpsee-ws-client",
+ "polkadot-sdk",
+ "primitive-types",
  "scale-bits",
- "scale-decode",
+ "scale-decode 0.14.0",
  "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
  "thiserror 1.0.69",
+ "tokio",
  "tokio-util",
  "tracing",
  "url",
+ "web-time",
 ]
 
 [[package]]
 name = "subxt-codegen"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d703dca0905cc5272d7cc27a4ac5f37dcaae7671acc7fef0200057cc8c317786"
+checksum = "6550ef451c77db6e3bc7c56fb6fe1dca9398a2c8fc774b127f6a396a769b9c5b"
 dependencies = [
- "frame-metadata 16.0.0",
  "heck 0.5.0",
- "hex",
- "jsonrpsee 0.22.5",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.98",
+ "syn 2.0.101",
  "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
 name = "subxt-core"
-version = "0.37.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af3b36405538a36b424d229dc908d1396ceb0994c90825ce928709eac1a159a"
+checksum = "cb7a1bc6c9c1724971636a66e3225a7253cdb35bb6efb81524a6c71c04f08c59"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
- "frame-metadata 16.0.0",
+ "frame-decode",
+ "frame-metadata 17.0.0",
  "hashbrown 0.14.5",
  "hex",
- "impl-serde 0.4.0",
+ "impl-serde",
+ "keccak-hash",
  "parity-scale-codec",
- "primitive-types 0.12.2",
+ "polkadot-sdk",
+ "primitive-types",
  "scale-bits",
- "scale-decode",
+ "scale-decode 0.14.0",
  "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9406fbdb9548c110803cb8afa750f8b911d51eefdf95474b11319591d225d9"
+checksum = "89ebc9131da4d0ba1f7814495b8cc79698798ccd52cacd7bcefe451e415bd945"
 dependencies = [
  "futures 0.3.31",
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light 0.14.0",
+ "smoldot-light 0.16.2",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -15029,54 +14820,72 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c195f803d70687e409aba9be6c87115b5da8952cd83c4d13f2e043239818fcd"
+checksum = "7819c5e09aae0319981ee853869f2fcd1fac4db8babd0d004c17161297aadc05"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "parity-scale-codec",
- "proc-macro-error",
+ "proc-macro-error2",
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "syn 2.0.98",
+ "subxt-utils-fetchmetadata",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738be5890fdeff899bbffff4d9c0f244fe2a952fb861301b937e3aa40ebb55da"
+checksum = "aacd4e7484fef58deaa2dcb32d94753a864b208a668c0dd0c28be1d8abeeadb2"
 dependencies = [
- "frame-metadata 16.0.0",
+ "frame-decode",
+ "frame-metadata 17.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
+ "polkadot-sdk",
  "scale-info",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "subxt-signer"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49888ae6ae90fe01b471193528eea5bd4ed52d8eecd2d13f4a2333b87388850"
+checksum = "d680352d04665b1e4eb6f9d2a54b800c4d8e1b20478e69be1b7d975b08d9fc34"
 dependencies = [
+ "base64 0.22.1",
  "bip32",
  "bip39",
  "cfg-if",
+ "crypto_secretbox",
  "hex",
  "hmac 0.12.1",
  "keccak-hash",
  "parity-scale-codec",
  "pbkdf2",
+ "polkadot-sdk",
  "regex",
  "schnorrkel 0.11.4",
- "secp256k1 0.28.2",
- "secrecy",
- "sha2 0.10.8",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scrypt",
+ "secp256k1 0.30.0",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "subxt-core",
  "zeroize",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c53bc3eeaacc143a2f29ace4082edd2edaccab37b69ad20befba9fb00fdb3d"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -15092,9 +14901,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15115,13 +14924,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15130,7 +14939,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -15159,22 +14968,21 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand 2.3.0",
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15188,11 +14996,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -15213,11 +15021,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -15237,7 +15045,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15248,18 +15056,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15310,9 +15118,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -15325,15 +15133,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -15350,9 +15158,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -15360,9 +15168,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -15375,9 +15183,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -15386,7 +15194,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -15399,37 +15207,16 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
-dependencies = [
- "rustls 0.23.23",
+ "rustls",
  "tokio",
 ]
 
@@ -15447,24 +15234,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -15485,9 +15273,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -15497,25 +15285,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -15538,9 +15333,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -15580,7 +15375,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15605,8 +15400,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15617,13 +15412,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15659,9 +15454,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
+checksum = "6c0670ab45a6b7002c7df369fee950a27cf29ae0474343fd3a15aa15f691e7a6"
 dependencies = [
  "hash-db",
  "log",
@@ -15679,78 +15474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.5.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand",
- "smallvec",
- "socket2 0.4.10",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.6.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "smallvec",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot 0.12.3",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trust-dns-proto 0.23.2",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15758,9 +15481,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
 dependencies = [
  "dissimilar",
  "glob",
@@ -15769,7 +15492,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -15780,20 +15503,20 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.3.1",
  "httparse",
  "log",
- "rand",
- "rustls 0.21.12",
+ "rand 0.9.1",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "url",
  "utf-8",
 ]
@@ -15812,7 +15535,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -15859,16 +15582,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -15884,12 +15601,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -15919,7 +15630,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.2",
  "bytes",
  "futures-io",
  "futures-util",
@@ -15954,7 +15665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
 ]
 
@@ -15963,12 +15674,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -16008,26 +15713,70 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-serialize-derive",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
- "rand",
- "rand_chacha",
- "rand_core",
- "sha2 0.10.8",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
  "sha3",
- "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "w3f-pcs"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe7a8d5c914b69392ab3b267f679a2e546fe29afaddce47981772ac71bd02e1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "merlin",
+]
+
+[[package]]
+name = "w3f-plonk-common"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aca389e494fe08c5c108b512e2328309036ee1c0bc7bdfdb743fef54d448c8c"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "getrandom_or_panic",
+ "rand_core 0.6.4",
+ "w3f-pcs",
+]
+
+[[package]]
+name = "w3f-ring-proof"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a639379402ad51504575dbd258740383291ac8147d3b15859bdf1ea48c677de"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "ark-transcript",
+ "w3f-pcs",
+ "w3f-plonk-common",
 ]
 
 [[package]]
@@ -16063,9 +15812,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -16101,7 +15850,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -16136,7 +15885,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -16223,7 +15972,24 @@ dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_arena",
- "wasmi_core",
+ "wasmi_core 0.13.0",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
+dependencies = [
+ "arrayvec 0.7.6",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_collections",
+ "wasmi_core 0.32.3",
  "wasmparser-nostd",
 ]
 
@@ -16234,10 +16000,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
+name = "wasmi_collections"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.5",
+ "string-interner",
+]
+
+[[package]]
 name = "wasmi_core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23b3a7f6c8c3ceeec6b83531ee61f0013c56e51cbf2b14b0f213548b23a4b41"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -16315,7 +16104,7 @@ dependencies = [
  "log",
  "rustix 0.36.17",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "toml 0.5.11",
  "windows-sys 0.45.0",
  "zstd 0.11.2+zstd.1.5.2",
@@ -16439,7 +16228,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -16470,13 +16259,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "ring 0.17.9",
- "untrusted 0.9.0",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -16486,18 +16293,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "westend-runtime"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "22.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16520,10 +16318,8 @@ dependencies = [
  "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
- "pallet-collective",
  "pallet-conviction-voting",
  "pallet-delegated-staking",
- "pallet-democracy",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
@@ -16533,7 +16329,8 @@ dependencies = [
  "pallet-indices",
  "pallet-membership",
  "pallet-message-queue",
- "pallet-migrations 9.0.0",
+ "pallet-meta-tx",
+ "pallet-migrations 10.1.0",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nomination-pools",
@@ -16560,6 +16357,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
+ "pallet-verify-signature",
  "pallet-vesting",
  "pallet-whitelist",
  "pallet-xcm",
@@ -16573,7 +16371,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "smallvec",
  "sp-api",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -16606,8 +16403,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -16632,9 +16429,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -16658,7 +16455,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16679,22 +16476,54 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
 dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.53.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result 0.3.3",
+ "windows-strings",
 ]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
@@ -16703,6 +16532,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -16780,11 +16627,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -16806,6 +16669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16822,6 +16691,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -16842,10 +16717,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -16866,6 +16753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16882,6 +16775,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -16902,6 +16801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16920,10 +16825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.2"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -16940,24 +16851,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -16975,26 +16880,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
-dependencies = [
- "asn1-rs 0.5.2",
- "data-encoding",
- "der-parser 8.2.0",
- "lazy_static",
- "nom",
- "oid-registry 0.6.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
 ]
 
 [[package]]
@@ -17015,6 +16903,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "xcm-primitives"
 version = "0.1.0"
 dependencies = [
@@ -17022,7 +16927,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "primitive-types 0.13.1",
+ "primitive-types",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -17031,19 +16936,19 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#5b297a074955154c7c40c1559c2807d682220b51"
+version = "11.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#ca929c305c38338b75086d061ca2633212ae6b17"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17056,9 +16961,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -17080,8 +16985,24 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
+dependencies = [
+ "futures 0.3.31",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.9.1",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]
@@ -17107,9 +17028,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -17119,56 +17040,55 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -17188,14 +17108,25 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -17204,13 +17135,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17253,9 +17184,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "hash-db",
  "log",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2191,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.19.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2288,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2339,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.23.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2432,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
+source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -3211,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
+source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
+source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
 dependencies = [
  "environmental",
  "evm-core",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
+source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -3448,7 +3448,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
+source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
+source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
 dependencies = [
  "environmental",
  "evm",
@@ -3515,8 +3515,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3539,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "47.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3739,8 +3739,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "33.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3760,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4600,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4630,7 +4630,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.1",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4691,9 +4691,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -4707,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -6233,7 +6233,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -6252,7 +6252,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6997,7 +6997,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7185,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "41.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7306,7 +7306,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.19.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7377,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7392,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7431,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7444,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
+source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "43.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7880,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8009,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8057,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8158,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8214,8 +8214,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "41.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8253,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8285,8 +8285,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "40.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8308,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8327,7 +8327,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "44.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8343,7 +8343,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8373,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8392,7 +8392,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8426,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8442,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8473,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "19.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -8551,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -8900,7 +8900,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9069,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -9104,7 +9104,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -9127,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9201,7 +9201,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9343,7 +9343,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9456,7 +9456,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -9473,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9498,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -9559,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -9626,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "19.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9749,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "19.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9948,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -10150,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
+source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/dimartiro/frontier?branch=master#ec2f1780ea6efe8c665d08ee3ec9b98e310023b2"
+source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
 dependencies = [
  "case",
  "num_enum",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -11054,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11385,7 +11385,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "sp-core",
@@ -11396,7 +11396,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11460,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "docify",
@@ -11486,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -11497,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -11539,7 +11539,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -11565,7 +11565,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11591,7 +11591,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11614,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11643,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11679,7 +11679,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -11701,7 +11701,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -11755,7 +11755,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11768,7 +11768,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -11812,7 +11812,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -11867,7 +11867,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11890,7 +11890,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11913,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11926,7 +11926,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "polkavm",
@@ -11937,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "anyhow",
  "log",
@@ -11953,7 +11953,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -11969,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -11983,7 +11983,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.49.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12061,7 +12061,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -12071,7 +12071,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -12090,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12111,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -12165,7 +12165,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bs58",
  "bytes",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bytes",
  "fnv",
@@ -12218,7 +12218,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12227,7 +12227,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -12259,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12279,7 +12279,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -12303,7 +12303,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.49.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -12335,7 +12335,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -12350,7 +12350,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "directories",
@@ -12414,7 +12414,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12425,7 +12425,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "clap",
  "fs4",
@@ -12438,7 +12438,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12457,7 +12457,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -12477,7 +12477,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -12496,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "chrono",
  "console",
@@ -12524,7 +12524,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -12535,7 +12535,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12567,7 +12567,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12584,7 +12584,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -13238,7 +13238,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13552,7 +13552,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "hash-db",
@@ -13574,7 +13574,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13588,7 +13588,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13600,7 +13600,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13614,7 +13614,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13626,7 +13626,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13636,7 +13636,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -13655,7 +13655,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13669,7 +13669,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13685,7 +13685,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13703,7 +13703,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13723,7 +13723,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13740,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13751,7 +13751,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -13812,7 +13812,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -13825,7 +13825,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
@@ -13835,7 +13835,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -13844,7 +13844,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13854,7 +13854,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13864,7 +13864,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13876,7 +13876,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13889,7 +13889,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bytes",
  "docify",
@@ -13915,7 +13915,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13925,7 +13925,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13936,7 +13936,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13945,7 +13945,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -13955,7 +13955,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13966,7 +13966,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13983,7 +13983,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13996,7 +13996,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14006,7 +14006,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "backtrace",
  "regex",
@@ -14015,7 +14015,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14025,7 +14025,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -14054,7 +14054,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "Inflector",
  "expander",
@@ -14086,7 +14086,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14100,7 +14100,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -14113,7 +14113,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "hash-db",
  "log",
@@ -14133,7 +14133,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -14157,12 +14157,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14174,7 +14174,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14186,7 +14186,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -14197,7 +14197,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14206,7 +14206,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14220,7 +14220,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "ahash",
  "hash-db",
@@ -14242,7 +14242,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14259,7 +14259,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -14271,7 +14271,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14283,7 +14283,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14352,7 +14352,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14365,7 +14365,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -14386,7 +14386,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "environmental",
  "frame-support",
@@ -14410,7 +14410,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "19.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14435,15 +14435,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "static_init"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
+checksum = "8bae1df58c5fea7502e8e352ec26b5579f6178e1fdb311e088580c980dee25ed"
 dependencies = [
  "bitflags 1.3.2",
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.2.1",
  "libc",
- "parking_lot 0.11.2",
- "parking_lot_core 0.8.6",
+ "parking_lot 0.12.3",
+ "parking_lot_core 0.9.10",
  "static_init_macro",
  "winapi",
 ]
@@ -14521,7 +14521,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -14533,12 +14533,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14558,7 +14558,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -14572,7 +14572,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14589,7 +14589,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14614,7 +14614,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -14658,7 +14658,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "futures 0.3.31",
  "sc-block-builder",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -15403,7 +15403,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15414,7 +15414,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -16296,8 +16296,8 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime"
-version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+version = "22.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16406,7 +16406,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -16488,14 +16488,14 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.3.3",
+ "windows-result 0.3.4",
  "windows-strings",
 ]
 
@@ -16538,18 +16538,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -16939,7 +16939,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -16950,7 +16950,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#1756db06b1d7794a23b7d069d76716a64d0524cc"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#a7da43206b3185b21e36734e3e0bb9af6a887e46"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2503#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2503#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "environmental",
  "evm",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2503#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -10150,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2503#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2503#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
+source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
+source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "environmental",
  "evm",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
+source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -10150,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
+source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/dimartiro/frontier?branch=master#3070ad5bb55df4bce0d83bb07521a06ab5955a2d"
+source = "git+https://github.com/polkadot-evm/frontier?branch=master#1c1041ebbdb46b30a637b2e7e38f21c0e42a89f7"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,7 +2612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -3211,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
 dependencies = [
  "environmental",
  "evm-core",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.42.0"
-source = "git+https://github.com/dimartiro/evm?branch=v0.x#2c51bc1234812b013130938d6543a911a0db34ef"
+source = "git+https://github.com/dimartiro/evm?branch=v0.x#051f5b3bed6189eeb9b7184321503f85ee22bd90"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -6880,7 +6880,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8630,8 +8630,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
-source = "git+https://github.com/paritytech/parity-scale-codec?rev=334b99c9cc8def7408bcd91d1ff7bfd79f7e2915#334b99c9cc8def7408bcd91d1ff7bfd79f7e2915"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -8646,8 +8647,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
-source = "git+https://github.com/paritytech/parity-scale-codec?rev=334b99c9cc8def7408bcd91d1ff7bfd79f7e2915#334b99c9cc8def7408bcd91d1ff7bfd79f7e2915"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ repository = "Moonsong-Labs/moonkit"
 # - "client" dependencies are only used in the client, and thus don't need to be no_std compatible.
 
 # Crates.io (wasm)
-async-trait = { version = "0.1.42" }
+async-trait = { version = "0.1.88" }
 environmental = { version = "1.1.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 impl-trait-for-tuples = "0.2.1"
-parity-scale-codec = { version = "3.0.0", default-features = false, features = [
+parity-scale-codec = { version = "3.7.4", default-features = false, features = [
     "derive",
 ] }
 futures = { version = "0.3.31", features = ["compat"] }
@@ -59,161 +59,161 @@ hex-literal = "0.4.1"
 pallet-foreign-asset-creator = { path = "pallets/foreign-asset-creator", default-features = false }
 
 # Substrate (wasm)
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-support-test = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-identity = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-referenda = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-root-testing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-society = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-whitelist = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-application-crypto = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-debug-derive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-sp-trie = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-support-test = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-identity = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-referenda = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-root-testing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-society = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-whitelist = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-application-crypto = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-debug-derive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+sp-trie = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
 
 # Substrate (client)
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-client-db = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-informant = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sc-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-sp-wasm-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-test-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-test-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-try-runtime-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-client-db = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-informant = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sc-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+sp-wasm-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-test-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-test-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+try-runtime-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
 # Cumulus (wasm)
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-staging-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+staging-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
 
 # Cumulus (client)
-cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-consensus-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-consensus-proposer = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-consensus-proposer = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
 # Polkadot (wasm)
-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-node-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-staging-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-staging-xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-staging-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-node-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+staging-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+staging-xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+staging-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
 
 # Polkadot (client)
-kusama-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-polkadot-node-subsystem = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-rococo-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-westend-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
-xcm-simulator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+kusama-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+polkadot-node-subsystem = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+rococo-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+westend-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
+xcm-simulator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
 # Frontier (wasm)
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
+fp-evm = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
+pallet-evm = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
+precompile-utils = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
 
 # EVM
-evm = { git = "https://github.com/rust-ethereum/evm", branch = "v0.x", default-features = false }
+evm = { git = "https://github.com/dimartiro/evm", branch = "v0.x", default-features = false }
 
 # Local (wasm)
 pallet-evm-precompile-balances-erc20 = { path = "precompiles/balances-erc20", default-features = false }
@@ -314,3 +314,9 @@ overflow-checks = true
 [profile.release]
 opt-level = 3
 panic = "unwind"
+
+# --- Patch to force use the correct parity-scale-codec version ---
+[patch.crates-io]
+parity-scale-codec = { git = "https://github.com/paritytech/parity-scale-codec", rev = "334b99c9cc8def7408bcd91d1ff7bfd79f7e2915", default-features = false, features = [
+	"derive",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ pallet-evm = { git = "https://github.com/dimartiro/frontier", branch = "master",
 precompile-utils = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
 
 # EVM
-evm = { git = "https://github.com/dimartiro/evm", branch = "v0.x", default-features = false }
+evm = { git = "https://github.com/rust-ethereum/evm", branch = "v0.x", default-features = false }
 
 # Local (wasm)
 pallet-evm-precompile-balances-erc20 = { path = "precompiles/balances-erc20", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,9 +208,9 @@ westend-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch =
 xcm-simulator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
 # Frontier (wasm)
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
+fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2503", default-features = false }
+pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2503", default-features = false }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2503", default-features = false }
 
 # EVM
 evm = { git = "https://github.com/rust-ethereum/evm", branch = "v0.x", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = { version = "0.1.88" }
 environmental = { version = "1.1.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 impl-trait-for-tuples = "0.2.1"
-parity-scale-codec = { version = "3.7.4", default-features = false, features = [
+parity-scale-codec = { version = "3.7.5", default-features = false, features = [
     "derive",
 ] }
 futures = { version = "0.3.31", features = ["compat"] }
@@ -314,9 +314,3 @@ overflow-checks = true
 [profile.release]
 opt-level = 3
 panic = "unwind"
-
-# --- Patch to force use the correct parity-scale-codec version ---
-[patch.crates-io]
-parity-scale-codec = { git = "https://github.com/paritytech/parity-scale-codec", rev = "334b99c9cc8def7408bcd91d1ff7bfd79f7e2915", default-features = false, features = [
-	"derive",
-] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,9 +208,9 @@ westend-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch =
 xcm-simulator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
 # Frontier (wasm)
-fp-evm = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
-pallet-evm = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
-precompile-utils = { git = "https://github.com/dimartiro/frontier", branch = "master", default-features = false }
+fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
+pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "master", default-features = false }
 
 # EVM
 evm = { git = "https://github.com/rust-ethereum/evm", branch = "v0.x", default-features = false }

--- a/pallets/author-slot-filter/src/num.rs
+++ b/pallets/author-slot-filter/src/num.rs
@@ -17,12 +17,24 @@
 //! Implements a [NonZeroU32] type that interplays nicely with the
 //! subtrate storage and the SCALE codec.
 
-use parity_scale_codec::{Decode, Encode, Error, Input};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, Error, Input};
 use scale_info::TypeInfo;
 use serde::de::Error as DeserializeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Debug, Default, TypeInfo, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Clone,
+	Debug,
+	Default,
+	TypeInfo,
+	Encode,
+	DecodeWithMemTracking,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Hash,
+)]
 pub struct NonZeroU32(u32);
 
 impl core::ops::Deref for NonZeroU32 {

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -15,13 +15,11 @@
 // along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_support::{
-	ensure,
-	traits::{Get, Time},
-};
+use frame_support::sp_runtime::traits::UniqueSaturatedInto;
+use frame_support::traits::Time;
+use frame_support::{ensure, traits::Get};
 use sp_core::H256;
 use sp_io::hashing::keccak_256;
-use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::vec::Vec;
 
 /// EIP2612 permit typehash.

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -155,6 +155,7 @@ fn testnet_genesis(
 				.cloned()
 				.map(|k| (k, 1 << 60))
 				.collect(),
+			dev_accounts: None,
 		},
 		parachain_info: moonkit_template_runtime::ParachainInfoConfig {
 			parachain_id: id,

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -260,7 +260,7 @@ where
 			.map(|cfg| &cfg.registry),
 	);
 
-	let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
+	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &parachain_config,
 			client: client.clone(),
@@ -352,8 +352,6 @@ where
 			true,
 		)?;
 	}
-
-	start_network.start_network();
 
 	Ok((task_manager, client))
 }
@@ -463,7 +461,7 @@ where
 		config.prometheus_config.as_ref().map(|cfg| &cfg.registry),
 	);
 
-	let (network, system_rpc_tx, tx_handler_controller, network_starter, sync_service) =
+	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &config,
 			client: client.clone(),
@@ -618,6 +616,5 @@ where
 		);
 	};
 
-	network_starter.start_network();
 	Ok(task_manager)
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -559,6 +559,7 @@ impl Config for XcmConfig {
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
 	type XcmRecorder = PolkadotXcm;
+	type XcmEventEmitter = ();
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.
@@ -599,6 +600,7 @@ impl pallet_xcm::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
+	type AuthorizedAliasConsideration = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {


### PR DESCRIPTION
# Description

Dependencies updated to `stable2503`

### Some changes

- `DecodeWithMemTracking` added for required types
- Adds new `dev_accounts` fields for `pallet_balances:Config`
- `sc_service::build_network` returns a touple of 4 arguments instead of 5 so I had to remove the `network_starter`
- Add new `XcmEventEmitter` and `AuthorizedAliasConsideration` for `XcmConfig`