### PR TITLE
Improvements to the ConsensusHook mechanism

### DIFF
--- a/pallets/async-backing/src/mock.rs
+++ b/pallets/async-backing/src/mock.rs
@@ -91,7 +91,7 @@ parameter_types! {
 impl async_backing::Config for Test {
 	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 	type GetAndVerifySlot = RelaySlot;
-	type ExpectedBlockTime = ConstU64<1>;
+	type SlotDuration = ConstU64<1>;
 }
 
 /// Build genesis storage according to the mock runtime.

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -357,7 +357,7 @@ parameter_types! {
 impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
-	type OnTimestampSet = ();
+	type OnTimestampSet = NimbusAsyncBacking;
 	type MinimumPeriod = MinimumPeriod;
 	type WeightInfo = ();
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -667,13 +667,13 @@ impl pallet_author_slot_filter::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExpectedBlockTime: u64 = MILLISECS_PER_BLOCK;
+	pub const SlotDuration: u64 = MILLISECS_PER_BLOCK;
 }
 
 impl pallet_async_backing::Config for Runtime {
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	type GetAndVerifySlot = pallet_async_backing::RelaySlot;
-	type ExpectedBlockTime = ExpectedBlockTime;
+	type SlotDuration = SlotDuration;
 }
 
 parameter_types! {


### PR DESCRIPTION
Implement `OnTimestampSet` for pallet async-backing. This can be used in the runtime to validate the new timestamp.