### PR TITLE
Fix maintenance-mode typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ pallet-author-inherent = { path = "pallets/author-inherent", default-features = 
 pallet-author-mapping = { path = "pallets/author-mapping", default-features = false }
 pallet-author-slot-filter = { path = "pallets/author-slot-filter", default-features = false }
 pallet-async-backing = { path = "pallets/async-backing", default-features = false }
-pallet-maintenance_mode = { path = "pallets/maintenance_mode", default-features = false }
+pallet-maintenance-mode = { path = "pallets/maintenance-mode", default-features = false }
 pallet-migrations = { path = "pallets/migrations", default-features = false }
 nimbus-primitives = { path = "primitives/nimbus-primitives", default-features = false }
 session-keys-primitives = { path = "primitives/session-keys", default-features = false }


### PR DESCRIPTION
Fix maintenance-mode typo in Cargo.toml

Doesn't affect anything because no packages depend on `pallet-maintenance-mode` inside the workspace. I guess it could also be removed.