### PR TITLE
Revert authoring_duration changes

### DIFF
--- a/client/consensus/nimbus-consensus/src/collators/basic.rs
+++ b/client/consensus/nimbus-consensus/src/collators/basic.rs
@@ -195,7 +195,7 @@ pub async fn run<Block, BI, CIDP, Backend, Client, RClient, Proposer, CS, ADP>(
 				&parent_header,
 				&mut proposer,
 				inherent_data,
-				Duration::from_millis(500), //params.authoring_duration,
+				params.authoring_duration,
 				allowed_pov_size,
 			)
 			.await


### PR DESCRIPTION
Recently, in https://github.com/Moonsong-Labs/moonkit/pull/76, I incorrectly committed some local changes. This PR reverts it.