### PR TITLE
Use PostInherents to validate timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6883,6 +6883,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-keystore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7213,6 +7213,7 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
+ "sp-timestamp",
  "sp-version",
  "substrate-prometheus-endpoint",
  "tracing",

--- a/client/consensus/nimbus-consensus/Cargo.toml
+++ b/client/consensus/nimbus-consensus/Cargo.toml
@@ -16,6 +16,7 @@ sp-blockchain = { workspace = true }
 sp-consensus = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
+sp-timestamp = { workspace = true }
 sp-keystore = { workspace = true }
 sp-runtime = { workspace = true }
 sp-version = { workspace = true }

--- a/client/consensus/nimbus-consensus/src/collators.rs
+++ b/client/consensus/nimbus-consensus/src/collators.rs
@@ -27,12 +27,16 @@ use crate::*;
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_client_consensus_common::{ParachainBlockImportMarker, ParachainCandidate};
 use cumulus_client_consensus_proposer::ProposerInterface;
-use cumulus_primitives_core::ParachainBlockData;
+use cumulus_primitives_core::{
+	relay_chain::{OccupiedCoreAssumption, ValidationCodeHash},
+	ParachainBlockData,
+};
 use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use futures::prelude::*;
 use log::{debug, info};
 use nimbus_primitives::{CompatibleDigestItem, DigestsProvider, NimbusId, NIMBUS_KEY_ID};
 use polkadot_node_primitives::{Collation, MaybeCompressedPoV};
+use polkadot_primitives::Hash as RelayHash;
 use sc_consensus::{BlockImport, BlockImportParams};
 use sp_application_crypto::ByteArray;
 use sp_consensus::{BlockOrigin, Proposal};
@@ -194,4 +198,55 @@ where
 		.expect("signature bytes produced by keystore should be right length");
 
 	<DigestItem as CompatibleDigestItem>::nimbus_seal(signature)
+}
+
+/// Check the `local_validation_code_hash` against the validation code hash in the relay chain
+/// state.
+///
+/// If the code hashes do not match, it prints a warning.
+async fn check_validation_code_or_log(
+	local_validation_code_hash: &ValidationCodeHash,
+	para_id: ParaId,
+	relay_client: &impl RelayChainInterface,
+	relay_parent: RelayHash,
+) {
+	let state_validation_code_hash = match relay_client
+		.validation_code_hash(relay_parent, para_id, OccupiedCoreAssumption::Included)
+		.await
+	{
+		Ok(hash) => hash,
+		Err(error) => {
+			tracing::debug!(
+				target: super::LOG_TARGET,
+				%error,
+				?relay_parent,
+				%para_id,
+				"Failed to fetch validation code hash",
+			);
+			return;
+		}
+	};
+
+	match state_validation_code_hash {
+		Some(state) => {
+			if state != *local_validation_code_hash {
+				tracing::warn!(
+					target: super::LOG_TARGET,
+					%para_id,
+					?relay_parent,
+					?local_validation_code_hash,
+					relay_validation_code_hash = ?state,
+					"Parachain code doesn't match validation code stored in the relay chain state.",
+				);
+			}
+		}
+		None => {
+			tracing::warn!(
+				target: super::LOG_TARGET,
+				%para_id,
+				?relay_parent,
+				"Could not find validation code for parachain in the relay chain state.",
+			);
+		}
+	}
 }

--- a/client/consensus/nimbus-consensus/src/collators/basic.rs
+++ b/client/consensus/nimbus-consensus/src/collators/basic.rs
@@ -172,6 +172,7 @@ pub async fn run<Block, BI, CIDP, Backend, Client, RClient, Proposer, CS, ADP>(
 				&relay_client,
 				*request.relay_parent(),
 				nimbus_id.clone(),
+				None
 			)
 			.await
 		);

--- a/client/consensus/nimbus-consensus/src/collators/lookahead.rs
+++ b/client/consensus/nimbus-consensus/src/collators/lookahead.rs
@@ -207,7 +207,7 @@ where
 			};
 
 			// Determine which is the current slot
-			let slot_now = match consensus_common::relay_slot_and_timestamp(
+			let (slot_now, timestamp) = match consensus_common::relay_slot_and_timestamp(
 				&relay_parent_header,
 				params.relay_chain_slot_duration,
 			) {
@@ -236,7 +236,7 @@ where
 						relay_chain_slot_duration = ?params.relay_chain_slot_duration,
 						"Adjusted relay-chain slot to parachain slot"
 					);
-					our_slot
+					(our_slot, relay_timestamp)
 				}
 			};
 
@@ -343,6 +343,7 @@ where
 						&params.relay_client,
 						relay_parent,
 						author_id.clone(),
+						Some(timestamp),
 					)
 					.await
 					{

--- a/pallets/async-backing/src/consensus_hook.rs
+++ b/pallets/async-backing/src/consensus_hook.rs
@@ -29,17 +29,50 @@ use frame_support::pallet_prelude::*;
 use sp_consensus_slots::Slot;
 use sp_std::{marker::PhantomData, num::NonZeroU32};
 
-/// A consensus hook for a fixed block processing velocity and unincluded segment capacity.
+/// A consensus hook that enforces fixed block production velocity and unincluded segment capacity.
 ///
-/// Relay chain slot duration must be provided in milliseconds.
-pub struct FixedVelocityConsensusHook<T, const V: u32, const C: u32>(PhantomData<T>);
+/// It keeps track of relay chain slot information and parachain blocks authored per relay chain
+/// slot.
+///
+/// # Type Parameters
+/// - `T` - The runtime configuration trait
+/// - `RELAY_CHAIN_SLOT_DURATION_MILLIS` - Duration of relay chain slots in milliseconds
+/// - `V` - Maximum number of blocks that can be authored per relay chain parent (velocity)
+/// - `C` - Maximum capacity of unincluded segment
+///
+/// # Example Configuration
+/// ```ignore
+/// type ConsensusHook = FixedVelocityConsensusHook<Runtime, 6000, 2, 8>;
+/// ```
+/// This configures:
+/// - 6 second relay chain slots
+/// - Maximum 2 blocks per slot
+/// - Maximum 8 blocks in unincluded segment
+pub struct FixedVelocityConsensusHook<
+	T,
+	const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32,
+	const V: u32,
+	const C: u32,
+>(PhantomData<T>);
 
-impl<T: pallet::Config, const V: u32, const C: u32> ConsensusHook
-	for FixedVelocityConsensusHook<T, V, C>
+impl<
+		T: pallet::Config,
+		const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32,
+		const V: u32,
+		const C: u32,
+	> ConsensusHook for FixedVelocityConsensusHook<T, RELAY_CHAIN_SLOT_DURATION_MILLIS, V, C>
 where
 	<T as pallet_timestamp::Config>::Moment: Into<u64>,
 {
-	// Validates the number of authored blocks within the slot with respect to the `V + 1` limit.
+	/// Consensus hook that performs validations on the provided relay chain state
+	/// proof:
+	/// - Ensures blocks are not produced faster than the specified velocity `V`
+	/// - Verifies parachain slot alignment with relay chain slot
+	///
+	/// # Panics
+	/// - When the relay chain slot from the state is smaller than the slot from the proof
+	/// - When the number of authored blocks exceeds velocity limit
+	/// - When parachain slot is ahead of the calculated slot from relay chain
 	fn on_state_proof(state_proof: &RelayChainStateProof) -> (Weight, UnincludedSegmentCapacity) {
 		let relay_chain_slot = state_proof
 			.read_slot()
@@ -49,7 +82,12 @@ where
 	}
 }
 
-impl<T: pallet::Config, const V: u32, const C: u32> FixedVelocityConsensusHook<T, V, C>
+impl<
+		T: pallet::Config,
+		const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32,
+		const V: u32,
+		const C: u32,
+	> FixedVelocityConsensusHook<T, RELAY_CHAIN_SLOT_DURATION_MILLIS, V, C>
 where
 	<T as pallet_timestamp::Config>::Moment: Into<u64>,
 {
@@ -59,32 +97,44 @@ where
 		// Ensure velocity is non-zero.
 		let velocity = V.max(1);
 
-		// Get and verify the parachain slot
-		let new_slot = T::GetAndVerifySlot::get_and_verify_slot(&relay_chain_slot)
-			.expect("slot number mismatch");
-
-		// Update Slot Info
-		let authored = match SlotInfo::<T>::get() {
-			Some((slot, authored)) if slot == new_slot => {
-				if !T::AllowMultipleBlocksPerSlot::get() {
-					panic!("Block invalid; Supplied slot number is not high enough");
-				}
-				authored + 1
+		let (relay_chain_slot, authored_in_relay) = match pallet::SlotInfo::<T>::get() {
+			Some((slot, authored)) if slot == relay_chain_slot => (slot, authored),
+			Some((slot, _)) if slot < relay_chain_slot => (relay_chain_slot, 0),
+			Some((slot, _)) => {
+				panic!("Slot moved backwards: stored_slot={slot:?}, relay_chain_slot={relay_chain_slot:?}")
 			}
-			Some((slot, _)) if slot < new_slot => 1,
-			Some(..) => {
-				panic!("slot moved backwards")
-			}
-			None => 1,
+			None => (relay_chain_slot, 0),
 		};
 
-		// Perform checks.
-		if authored > velocity + 1 {
-			panic!("authored blocks limit is reached for the slot")
+		// We need to allow one additional block to be built to fill the unincluded segment.
+		if authored_in_relay > velocity {
+			panic!("authored blocks limit is reached for the slot: relay_chain_slot={relay_chain_slot:?}, authored={authored_in_relay:?}, velocity={velocity:?}");
 		}
 
 		// Store new slot info
-		SlotInfo::<T>::put((new_slot, authored));
+		SlotInfo::<T>::put((relay_chain_slot, authored_in_relay + 1));
+
+		// Get and verify the parachain slot
+		let para_slot = T::GetAndVerifySlot::get_and_verify_slot(&relay_chain_slot)
+			.expect("slot number mismatch");
+
+		// Convert relay chain timestamp.
+		let relay_chain_timestamp =
+			u64::from(RELAY_CHAIN_SLOT_DURATION_MILLIS).saturating_mul(*relay_chain_slot);
+
+		let para_slot_duration = SlotDuration::from_millis(T::SlotDuration::get().into());
+		let para_slot_from_relay =
+			Slot::from_timestamp(relay_chain_timestamp.into(), para_slot_duration);
+
+		if *para_slot > *para_slot_from_relay {
+			panic!(
+				"Parachain slot is too far in the future: parachain_slot={:?}, derived_from_relay_slot={:?} velocity={:?}, relay_chain_slot={:?}",
+				para_slot,
+				para_slot_from_relay,
+				velocity,
+				relay_chain_slot
+			);
+		}
 
 		// Account weights
 		let weight = T::DbWeight::get().reads_writes(1, 1);
@@ -92,15 +142,19 @@ where
 		// Return weight and unincluded segment capacity
 		(
 			weight,
-			NonZeroU32::new(sp_std::cmp::max(C, 1))
+			NonZeroU32::new(core::cmp::max(C, 1))
 				.expect("1 is the minimum value and non-zero; qed")
 				.into(),
 		)
 	}
 }
 
-impl<T: pallet::Config + parachain_system::Config, const V: u32, const C: u32>
-	FixedVelocityConsensusHook<T, V, C>
+impl<
+		T: pallet::Config + parachain_system::Config,
+		const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32,
+		const V: u32,
+		const C: u32,
+	> FixedVelocityConsensusHook<T, RELAY_CHAIN_SLOT_DURATION_MILLIS, V, C>
 {
 	/// Whether it is legal to extend the chain, assuming the given block is the most
 	/// recently included one as-of the relay parent that will be built against, and
@@ -114,7 +168,7 @@ impl<T: pallet::Config + parachain_system::Config, const V: u32, const C: u32>
 	/// is more recent than the included block itself.
 	pub fn can_build_upon(included_hash: T::Hash, new_slot: Slot) -> bool {
 		let velocity = V.max(1);
-		let (last_slot, authored_so_far) = match pallet::Pallet::<T>::slot_info() {
+		let (last_slot, authored_so_far) = match pallet::SlotInfo::<T>::get() {
 			None => return true,
 			Some(x) => x,
 		};
@@ -127,6 +181,8 @@ impl<T: pallet::Config + parachain_system::Config, const V: u32, const C: u32>
 			return false;
 		}
 
+		// Check that we have not authored more than `V + 1` parachain blocks in the current relay
+		// chain slot.
 		if last_slot == new_slot {
 			authored_so_far < velocity + 1
 		} else {

--- a/pallets/async-backing/src/consensus_hook.rs
+++ b/pallets/async-backing/src/consensus_hook.rs
@@ -98,7 +98,13 @@ where
 		let velocity = V.max(1);
 
 		let (relay_chain_slot, authored_in_relay) = match pallet::SlotInfo::<T>::get() {
-			Some((slot, authored)) if slot == relay_chain_slot => (slot, authored),
+			Some((slot, authored)) if slot == relay_chain_slot => {
+				if !T::AllowMultipleBlocksPerSlot::get() {
+					panic!("Block invalid; Supplied slot number is not high enough");
+				}
+
+				(slot, authored)
+			}
 			Some((slot, _)) if slot < relay_chain_slot => (relay_chain_slot, 0),
 			Some((slot, _)) => {
 				panic!("Slot moved backwards: stored_slot={slot:?}, relay_chain_slot={relay_chain_slot:?}")

--- a/pallets/async-backing/src/mock.rs
+++ b/pallets/async-backing/src/mock.rs
@@ -85,12 +85,13 @@ impl pallet_timestamp::Config for Test {
 
 parameter_types! {
 	pub const AllowMultipleBlocksPerSlot: bool = true;
-	pub const SlotDuration: u64 = 12000;
+	pub const SlotDuration: u64 = 6_000;
 }
 
 impl async_backing::Config for Test {
 	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 	type GetAndVerifySlot = RelaySlot;
+	type SlotDuration = SlotDuration;
 	type ExpectedBlockTime = ConstU64<1>;
 }
 

--- a/pallets/async-backing/src/tests.rs
+++ b/pallets/async-backing/src/tests.rs
@@ -18,7 +18,7 @@ use crate::consensus_hook::FixedVelocityConsensusHook;
 use crate::mock::*;
 use std::ops::Deref;
 
-type ConsensusHook = FixedVelocityConsensusHook<Test, 1, 1>;
+type ConsensusHook = FixedVelocityConsensusHook<Test, 6_000, 1, 1>;
 
 fn assert_slot_info_eq(slot_number: u64, authored: u32) {
 	assert_eq!(AsyncBacking::slot_info().unwrap().0.deref(), &slot_number);

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -75,6 +75,7 @@ sp-runtime = { workspace = true }
 sp-session = { workspace = true }
 sp-timestamp = { workspace = true }
 sp-transaction-pool = { workspace = true }
+sp-consensus-slots = { workspace = true }
 
 # Cumulus dependencies
 cumulus-client-cli = { workspace = true }

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -47,6 +47,7 @@ use sc_network::{
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sp_api::ProvideRuntimeApi;
+use sp_consensus_slots::SlotDuration;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::Block as BlockT;
 use substrate_prometheus_endpoint::Registry;
@@ -411,6 +412,8 @@ fn start_consensus(
 		additional_digests_provider: (),
 		collator_key,
 		authoring_duration: Duration::from_millis(500),
+		relay_chain_slot_duration: Duration::from_millis(6_000),
+		slot_duration: Some(SlotDuration::from_millis(6_000)),
 	};
 
 	let fut = nimbus_consensus::collators::basic::run::<Block, _, _, ParachainBackend, _, _, _, _, _>(


### PR DESCRIPTION
Preparation for https://github.com/paritytech/polkadot-sdk/pull/9732, which removes the deprecated `CheckInherents` parameter from `register_validate_block!` 

