### PR TITLE
[author-slot-filter] Add `using_fake_author` logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,6 +7265,7 @@ dependencies = [
 name = "pallet-author-slot-filter"
 version = "0.9.0"
 dependencies = [
+ "environmental",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",

--- a/pallets/author-slot-filter/Cargo.toml
+++ b/pallets/author-slot-filter/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 version = "0.9.0"
 
 [dependencies]
+environmental = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 log = { workspace = true }

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -94,7 +94,6 @@ pub mod pallet {
 			T::DbWeight::get().reads_writes(0, 1)
 		}
 	}
-	/// --------
 
 	/// Compute a pseudo-random subset of the input accounts by using Pallet's
 	/// source of randomness, `Config::RandomnessSource`.

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -57,7 +57,7 @@ pub mod pallet {
 	use sp_std::vec::Vec;
 
 	/// Storage key to be used for fake author logic
-	const IS_FAKE_AUTHOR_KEY: &[u8] = b"AuthorSlotFilter:IsFakeAuthor";
+	pub(crate) const IS_FAKE_AUTHOR_KEY: &[u8] = b"AuthorSlotFilter:IsFakeAuthor";
 
 	environmental::environmental!(IS_FAKE_AUTHOR: ());
 	/// Use fake author logic
@@ -85,13 +85,15 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
+	/// Hook to set the fake author logic storage key when using fake author logic
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
 			if IS_FAKE_AUTHOR::with(|_| ()).is_some() {
 				unhashed::put(IS_FAKE_AUTHOR_KEY, &());
 			}
-			T::DbWeight::get().reads_writes(0, 1)
+			// Account for 1 write to the fake author logic storage key
+			T::DbWeight::get().writes(1)
 		}
 	}
 

--- a/pallets/author-slot-filter/src/tests.rs
+++ b/pallets/author-slot-filter/src/tests.rs
@@ -19,8 +19,9 @@ pub use crate::mock::*;
 use crate::num::NonZeroU32;
 
 use frame_support::assert_ok;
-use frame_support::traits::OnRuntimeUpgrade;
+use frame_support::traits::{OnInitialize, OnRuntimeUpgrade};
 use frame_support::weights::Weight;
+use nimbus_primitives::CanAuthor;
 use sp_runtime::Percent;
 
 #[test]
@@ -95,5 +96,15 @@ fn test_migration_inserts_default_value_for_missing_eligible_ratio() {
 
 		let actual_eligible_count = AuthorSlotFilter::eligible_count();
 		assert_eq!(expected_default_eligible_count, actual_eligible_count);
+	});
+}
+
+#[test]
+fn test_using_fake_author_works() {
+	new_test_ext().execute_with(|| {
+		using_fake_author(|| {
+			AuthorSlotFilter::on_initialize(System::block_number());
+			assert!(AuthorSlotFilter::can_author(&42, &42));
+		});
 	});
 }

--- a/pallets/author-slot-filter/src/tests.rs
+++ b/pallets/author-slot-filter/src/tests.rs
@@ -19,6 +19,7 @@ pub use crate::mock::*;
 use crate::num::NonZeroU32;
 
 use frame_support::assert_ok;
+use frame_support::storage::unhashed;
 use frame_support::traits::{OnInitialize, OnRuntimeUpgrade};
 use frame_support::weights::Weight;
 use nimbus_primitives::CanAuthor;
@@ -27,6 +28,9 @@ use sp_runtime::Percent;
 #[test]
 fn test_set_eligibility_works() {
 	new_test_ext().execute_with(|| {
+		// Fake logic storage key should be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+
 		let value = num::NonZeroU32::new_unchecked(34);
 
 		assert_ok!(AuthorSlotFilter::set_eligible(
@@ -41,6 +45,9 @@ fn test_set_eligibility_works() {
 #[test]
 fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count() {
 	new_test_ext().execute_with(|| {
+		// Fake logic storage key should be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+
 		let input_eligible_ratio = Percent::from_percent(50);
 		let total_author_count = mock::Authors::get().len();
 		let eligible_author_count = input_eligible_ratio.mul_ceil(total_author_count) as u32;
@@ -64,6 +71,9 @@ fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count
 #[test]
 fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_eligible_count() {
 	new_test_ext().execute_with(|| {
+		// Fake logic storage key should be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+
 		let input_eligible_ratio = Percent::from_percent(0);
 		let expected_eligible_count = EligibilityValue::default();
 		let expected_weight =
@@ -85,6 +95,9 @@ fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_e
 #[test]
 fn test_migration_inserts_default_value_for_missing_eligible_ratio() {
 	new_test_ext().execute_with(|| {
+		// Fake logic storage key should be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+
 		let default_eligible_ratio = Percent::from_percent(50);
 		let expected_default_eligible_count =
 			NonZeroU32::new_unchecked(default_eligible_ratio.mul_ceil(Authors::get().len() as u32));
@@ -100,10 +113,44 @@ fn test_migration_inserts_default_value_for_missing_eligible_ratio() {
 }
 
 #[test]
+fn test_can_author_works() {
+	new_test_ext().execute_with(|| {
+		// Fake logic storage key should be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+		AuthorSlotFilter::on_initialize(System::block_number());
+		// Fake logic storage key should still be empty
+		assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
+
+		// PotentialAuthors can author every slot
+		for author in <Test as pallet::Config>::PotentialAuthors::get() {
+			assert!(AuthorSlotFilter::can_author(&author, &0));
+			assert!(AuthorSlotFilter::can_author(&author, &1));
+			assert!(AuthorSlotFilter::can_author(&author, &42));
+		}
+
+		// Author outside of PotentialAuthors cannot author any slot
+		assert!(!AuthorSlotFilter::can_author(&42, &0));
+		assert!(!AuthorSlotFilter::can_author(&42, &1));
+		assert!(!AuthorSlotFilter::can_author(&42, &42));
+	});
+}
+
+#[test]
 fn test_using_fake_author_works() {
 	new_test_ext().execute_with(|| {
 		using_fake_author(|| {
+			// Fake logic storage key should be empty
+			assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_none());
 			AuthorSlotFilter::on_initialize(System::block_number());
+			// Fake logic storage key should now be set
+			assert!(unhashed::get::<()>(IS_FAKE_AUTHOR_KEY).is_some());
+
+			// Author 1 can still author every slot
+			assert!(AuthorSlotFilter::can_author(&1, &0));
+
+			// Fake (any) author can also author every slot when using fake author logic
+			assert!(AuthorSlotFilter::can_author(&42, &0));
+			assert!(AuthorSlotFilter::can_author(&42, &1));
 			assert!(AuthorSlotFilter::can_author(&42, &42));
 		});
 	});


### PR DESCRIPTION
This PR adds the "fake author logic" to `pallet_author_slot_filter` so we can bypass the `can_author()` check.
The motivation here is to use this logic when in a pending block workflow.