### PR TITLE
feat: Make the async-backing relay parent offset dynamic

### DIFF
--- a/pallets/async-backing/src/lib.rs
+++ b/pallets/async-backing/src/lib.rs
@@ -78,6 +78,7 @@ where
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use frame_system::pallet_prelude::*;
 
 	/// The current storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -117,6 +118,39 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn slot_info)]
 	pub type SlotInfo<T: Config> = StorageValue<_, (Slot, u32), OptionQuery>;
+
+	#[pallet::type_value]
+	pub fn DefaultRelayParentOffset<T: Config>() -> u32 {
+		1
+	}
+
+	/// Relay parent offset enforced by the parachain-system inherent check.
+	#[pallet::storage]
+	#[pallet::getter(fn relay_parent_offset)]
+	pub type RelayParentOffset<T: Config> =
+		StorageValue<_, u32, ValueQuery, DefaultRelayParentOffset<T>>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Update the relay parent offset. Intended to be called by governance.
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::DbWeight::get().writes(1))]
+		pub fn set_relay_parent_offset(
+			origin: OriginFor<T>,
+			new: u32,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			RelayParentOffset::<T>::put(new);
+
+			Ok(Default::default())
+		}
+	}
+}
+
+impl<T: Config> Get<u32> for Pallet<T> {
+	fn get() -> u32 {
+		RelayParentOffset::<T>::get()
+	}
 }
 
 impl<T: Config> frame_support::traits::PostInherents for Pallet<T> {

--- a/pallets/async-backing/src/tests.rs
+++ b/pallets/async-backing/src/tests.rs
@@ -16,6 +16,7 @@
 
 use crate::consensus_hook::FixedVelocityConsensusHook;
 use crate::mock::*;
+use frame_support::{assert_noop, assert_ok};
 use std::ops::Deref;
 
 type ConsensusHook = FixedVelocityConsensusHook<Test, 6_000, 1, 1>;
@@ -66,5 +67,23 @@ fn can_skip_a_relay_slot() {
 		assert_slot_info_eq(1, 1);
 		ConsensusHook::on_state_proof_inner(3.into());
 		assert_slot_info_eq(3, 1);
+	});
+}
+
+#[test]
+fn relay_parent_offset_defaults_to_one_and_can_be_changed_by_root() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(AsyncBacking::relay_parent_offset(), 1);
+
+		assert_noop!(
+			AsyncBacking::set_relay_parent_offset(RuntimeOrigin::signed(1), 2),
+			sp_runtime::DispatchError::BadOrigin,
+		);
+
+		assert_ok!(AsyncBacking::set_relay_parent_offset(
+			RuntimeOrigin::root(),
+			2
+		));
+		assert_eq!(AsyncBacking::relay_parent_offset(), 2);
 	});
 }


### PR DESCRIPTION
## Goal

Make the async-backing relay parent offset dynamic so downstream runtimes can use a governance-controlled storage value for both authoring/runtime APIs and parachain-system consensus checks.

## What changed

- Added `RelayParentOffset` storage to `pallet-async-backing`, defaulting to `1`.
- Added Root-only `set_relay_parent_offset(new: u32)` dispatchable to update the offset on-chain.
- Implemented `Get<u32>` for `pallet_async_backing::Pallet<T>`, allowing runtimes to wire the pallet directly into `cumulus_pallet_parachain_system::Config::RelayParentOffset`.
- Added unit coverage for the default value, Root-only authorization, and successful updates.

## Reviewer notes

This keeps the current effective default offset at `1`, while allowing downstream runtimes to remove hardcoded constants and enforce the same offset value through parachain-system inherent checks.

Downstream runtimes still need to opt in by wiring:
- `type RelayParentOffset = AsyncBacking;`
- any runtime API offset getter to `AsyncBacking::relay_parent_offset()`
